### PR TITLE
push_then_pop is added to PriorityQueue

### DIFF
--- a/orx-priority-queue/src/dary/daryheap.rs
+++ b/orx-priority-queue/src/dary/daryheap.rs
@@ -1,6 +1,7 @@
 use super::heap::Heap;
 use crate::{positions::none::HeapPositionsNone, PriorityQueue};
 
+#[derive(Clone)]
 pub struct DaryHeap<N, K, const D: usize>
 where
     N: Clone,
@@ -63,5 +64,8 @@ where
     }
     fn push(&mut self, node: N, key: K) {
         self.heap.push(node, key)
+    }
+    fn push_then_pop(&mut self, node: N, key: K) -> (N, K) {
+        self.heap.push_then_pop(node, key)
     }
 }

--- a/orx-priority-queue/src/dary/daryheap_index.rs
+++ b/orx-priority-queue/src/dary/daryheap_index.rs
@@ -3,6 +3,7 @@ use crate::{
     positions::has_index::HeapPositionsHasIndex, HasIndex, PriorityQueue, PriorityQueueDecKey,
 };
 
+#[derive(Clone)]
 pub struct DaryHeapOfIndices<N, K, const D: usize>
 where
     N: HasIndex,
@@ -51,6 +52,9 @@ where
     }
     fn push(&mut self, node: N, key: K) {
         self.heap.push(node, key)
+    }
+    fn push_then_pop(&mut self, node: N, key: K) -> (N, K) {
+        self.heap.push_then_pop(node, key)
     }
 }
 impl<N, K, const D: usize> PriorityQueueDecKey<N, K> for DaryHeapOfIndices<N, K, D>

--- a/orx-priority-queue/src/dary/daryheap_map.rs
+++ b/orx-priority-queue/src/dary/daryheap_map.rs
@@ -2,6 +2,7 @@ use super::heap::Heap;
 use crate::{positions::map::HeapPositionsMap, PriorityQueue, PriorityQueueDecKey};
 use std::hash::Hash;
 
+#[derive(Clone)]
 pub struct DaryHeapWithMap<N, K, const D: usize>
 where
     N: Eq + Hash + Clone,
@@ -64,6 +65,9 @@ where
     }
     fn push(&mut self, node: N, key: K) {
         self.heap.push(node, key)
+    }
+    fn push_then_pop(&mut self, node: N, key: K) -> (N, K) {
+        self.heap.push_then_pop(node, key)
     }
 }
 impl<N, K, const D: usize> PriorityQueueDecKey<N, K> for DaryHeapWithMap<N, K, D>

--- a/orx-priority-queue/src/dary/heap.rs
+++ b/orx-priority-queue/src/dary/heap.rs
@@ -3,6 +3,7 @@ use crate::{
     PriorityQueue, PriorityQueueDecKey,
 };
 
+#[derive(Clone)]
 pub(crate) struct Heap<N, K, P, const D: usize>
 where
     N: Clone,
@@ -209,6 +210,20 @@ where
         self.positions.insert(&node, position);
         self.tree.push((node, key));
         self.heapify_up(position);
+    }
+
+    fn push_then_pop(&mut self, node: N, key: K) -> (N, K) {
+        if self.tree.is_empty() || self.tree[0].1 >= key {
+            (node, key)
+        } else {
+            self.positions.remove(&self.tree[0].0);
+            self.positions.insert(&node, 0);
+            let popped_node = self.tree[0].clone();
+            self.tree[0].0 = node;
+            self.tree[0].1 = key;
+            self.heapify_down(0);
+            popped_node
+        }
     }
 }
 

--- a/orx-priority-queue/src/positions/has_index.rs
+++ b/orx-priority-queue/src/positions/has_index.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 /// using usize::MAX as None
 const NONE: usize = usize::MAX;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HeapPositionsHasIndex<N>
 where
     N: HasIndex,

--- a/orx-priority-queue/src/positions/heap_positions.rs
+++ b/orx-priority-queue/src/positions/heap_positions.rs
@@ -1,4 +1,4 @@
-pub(crate) trait HeapPositions<N> {
+pub(crate) trait HeapPositions<N>: Clone {
     fn contains(&self, node: &N) -> bool;
     fn position_of(&self, node: &N) -> Option<usize>;
     fn clear(&mut self);

--- a/orx-priority-queue/src/positions/map.rs
+++ b/orx-priority-queue/src/positions/map.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, hash::Hash};
 
 use super::heap_positions::{HeapPositions, HeapPositionsDecKey};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HeapPositionsMap<N>
 where
     N: Eq + Hash + Clone,

--- a/orx-priority-queue/src/positions/none.rs
+++ b/orx-priority-queue/src/positions/none.rs
@@ -1,6 +1,6 @@
 use super::heap_positions::HeapPositions;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct HeapPositionsNone;
 
 impl<N> HeapPositions<N> for HeapPositionsNone {

--- a/orx-priority-queue/src/priority_queue.rs
+++ b/orx-priority-queue/src/priority_queue.rs
@@ -1,6 +1,6 @@
 /// A priority queue which allows pushing ([N], [K])=(node, key) pairs to the collection,
 /// and popping the foremost element having the lowest key.
-pub trait PriorityQueue<N, K>
+pub trait PriorityQueue<N, K>: Clone
 where
     K: PartialOrd,
 {
@@ -30,4 +30,12 @@ where
 
     /// Pushes the given ([node], [key]) pair to the queue.
     fn push(&mut self, node: N, key: K);
+
+    /// Performs the [push] with given ([node], [key]) followed by the [pop] operation.
+    ///
+    /// Since the queue cannot be empty after the push, the return type is not optional.
+    ///
+    /// The reason of merging the calls is that handling two instructions at once
+    /// is more efficient for certain implementations, such as the binary heap,
+    fn push_then_pop(&mut self, node: N, key: K) -> (N, K);
 }

--- a/orx-priority-queue/tests/daryheap.rs
+++ b/orx-priority-queue/tests/daryheap.rs
@@ -15,12 +15,14 @@ fn test_dary_forall() {
 }
 
 fn test_dary_for<const D: usize>() {
-    let empty_heap = DaryHeap::<usize, f64, D>::default;
+    let new_heap = DaryHeap::<usize, f64, D>::default;
 
-    test_len(empty_heap());
-    test_is_empty(empty_heap());
-    test_peek(empty_heap());
-    test_clear(empty_heap());
-    test_push_pop(empty_heap());
-    test_push_pop_randomized(empty_heap())
+    test_len(new_heap());
+    test_is_empty(new_heap());
+    test_peek(new_heap());
+    test_clear(new_heap());
+    test_push_pop(new_heap());
+    test_push_pop_randomized(new_heap());
+    test_push_then_pop(new_heap());
+    test_push_then_pop_randomized(new_heap());
 }

--- a/orx-priority-queue/tests/daryheap_4.rs
+++ b/orx-priority-queue/tests/daryheap_4.rs
@@ -5,36 +5,45 @@ use priority_queue_tests::*;
 
 const D: usize = 4;
 
-fn empty_heap() -> DaryHeap<usize, f64, D> {
+fn new_heap() -> DaryHeap<usize, f64, D> {
     DaryHeap::default()
 }
 
 #[test]
 fn len() {
-    test_len(empty_heap())
+    test_len(new_heap())
 }
 
 #[test]
 fn is_empty() {
-    test_is_empty(empty_heap())
+    test_is_empty(new_heap())
 }
 
 #[test]
 fn peek() {
-    test_peek(empty_heap())
+    test_peek(new_heap())
 }
 
 #[test]
 fn clear() {
-    test_clear(empty_heap())
+    test_clear(new_heap())
 }
 
 #[test]
 fn push_pop() {
-    test_push_pop(empty_heap())
+    test_push_pop(new_heap())
 }
 
 #[test]
 fn push_pop_randomized() {
-    test_push_pop_randomized(empty_heap())
+    test_push_pop_randomized(new_heap())
+}
+
+#[test]
+fn push_then_pop() {
+    test_push_then_pop(new_heap())
+}
+#[test]
+fn push_then_pop_randomized() {
+    test_push_then_pop_randomized(new_heap())
 }

--- a/orx-priority-queue/tests/daryheap_of_indices.rs
+++ b/orx-priority-queue/tests/daryheap_of_indices.rs
@@ -31,6 +31,8 @@ fn test_dary_for<const D: usize>() {
     test_clear(new_heap());
     test_push_pop(new_heap());
     test_push_pop_randomized(new_heap());
+    test_push_then_pop(new_heap());
+    test_push_then_pop_randomized(new_heap());
 
     test_contains(new_heap());
     test_key_of(new_heap());

--- a/orx-priority-queue/tests/daryheap_of_indices_4.rs
+++ b/orx-priority-queue/tests/daryheap_of_indices_4.rs
@@ -42,6 +42,15 @@ fn push_pop_randomized() {
 }
 
 #[test]
+fn push_then_pop() {
+    test_push_then_pop(new_heap())
+}
+#[test]
+fn push_then_pop_randomized() {
+    test_push_then_pop_randomized(new_heap())
+}
+
+#[test]
 fn contains() {
     test_contains(new_heap());
 }

--- a/orx-priority-queue/tests/daryheap_with_map.rs
+++ b/orx-priority-queue/tests/daryheap_with_map.rs
@@ -31,6 +31,8 @@ fn test_dary_for<const D: usize>() {
     test_clear(new_heap());
     test_push_pop(new_heap());
     test_push_pop_randomized(new_heap());
+    test_push_then_pop(new_heap());
+    test_push_then_pop_randomized(new_heap());
 
     test_contains(new_heap());
     test_key_of(new_heap());

--- a/orx-priority-queue/tests/daryheap_with_map_4.rs
+++ b/orx-priority-queue/tests/daryheap_with_map_4.rs
@@ -42,6 +42,15 @@ fn push_pop_randomized() {
 }
 
 #[test]
+fn push_then_pop() {
+    test_push_then_pop(new_heap())
+}
+#[test]
+fn push_then_pop_randomized() {
+    test_push_then_pop_randomized(new_heap())
+}
+
+#[test]
 fn contains() {
     test_contains(new_heap());
 }

--- a/orx-priority-queue/tests/priority_queue_tests/mod.rs
+++ b/orx-priority-queue/tests/priority_queue_tests/mod.rs
@@ -3,9 +3,11 @@ mod is_empty;
 mod len;
 mod peek;
 mod push_pop;
+mod push_then_pop;
 
 pub use clear::test_clear;
 pub use is_empty::test_is_empty;
 pub use len::test_len;
 pub use peek::test_peek;
 pub use push_pop::{test_push_pop, test_push_pop_randomized};
+pub use push_then_pop::{test_push_then_pop, test_push_then_pop_randomized};

--- a/orx-priority-queue/tests/priority_queue_tests/push_pop.rs
+++ b/orx-priority-queue/tests/priority_queue_tests/push_pop.rs
@@ -8,8 +8,8 @@ pub fn test_push_pop<P>(mut pq: P)
 where
     P: PriorityQueue<usize, f64>,
 {
-    const N: usize = 3;
-    const M: usize = 3;
+    const N: usize = 70;
+    const M: usize = 50;
 
     pq.clear();
     assert_eq!(0, pq.len());

--- a/orx-priority-queue/tests/priority_queue_tests/push_then_pop.rs
+++ b/orx-priority-queue/tests/priority_queue_tests/push_then_pop.rs
@@ -1,0 +1,77 @@
+use orx_priority_queue::PriorityQueue;
+use rand::prelude::*;
+
+pub fn test_push_then_pop<P>(mut pq: P)
+where
+    P: PriorityQueue<usize, f64>,
+{
+    // init
+    pq.clear();
+    assert_eq!(0, pq.len());
+
+    // when empty
+    let popped = pq.push_then_pop(0, 10.0);
+    assert_eq!((0, 10.0), popped);
+
+    // when better than the only item
+    pq.push(1, 20.0);
+    let popped = pq.push_then_pop(0, 10.0);
+    assert_eq!((0, 10.0), popped);
+
+    // when worse than the only item
+    pq.clear();
+    pq.push(1, 5.0);
+    let popped = pq.push_then_pop(0, 10.0);
+    assert_eq!((1, 5.0), popped);
+    assert_eq!(Some(&(0, 10.0)), pq.peek());
+
+    // when better than all items
+    pq.clear();
+    for i in 1..10 {
+        pq.push(i, 100.0 - i as f64);
+    }
+    let popped = pq.push_then_pop(0, 10.0);
+    assert_eq!((0, 10.0), popped);
+
+    // when worse than the best item
+    let popped = pq.push_then_pop(0, 100.0);
+    assert_ne!((0, 10.0), popped);
+}
+
+pub fn test_push_then_pop_randomized<P>(mut pq: P)
+where
+    P: PriorityQueue<usize, f64>,
+{
+    const N: usize = 50;
+
+    // fill it up
+    pq.clear();
+    assert!(pq.is_empty());
+
+    let mut rng = rand::thread_rng();
+    for node in 0..N {
+        let priority = rng.gen();
+        pq.push(node, priority);
+    }
+    let mut pq_pll = pq.clone();
+
+    // push & pull randomly
+    for node in N..2 * N {
+        let key = rng.gen();
+
+        pq_pll.push(node, key);
+        let popped_pll = pq_pll.pop().unwrap();
+
+        let popped = pq.push_then_pop(node, key);
+
+        assert_eq!(popped_pll, popped);
+    }
+    assert_eq!(pq.len(), N);
+
+    // pop remaining in correct order
+    while let Some(popped) = pq.pop() {
+        let popped_pll = pq_pll.pop().unwrap();
+        assert_eq!(popped_pll, popped);
+    }
+    assert!(pq_pll.is_empty());
+}


### PR DESCRIPTION
* `push_then_pop` method is added to the PriorityQueue.
* Implemented for the dary heap.
* Method is tested.
* Also Clone is required for PriorityQueue. This is essential for state definitions including a queue; and further, is useful for tests.