### PR TITLE
as_slice is implemented

### DIFF
--- a/orx-priority-queue/src/dary/daryheap.rs
+++ b/orx-priority-queue/src/dary/daryheap.rs
@@ -47,6 +47,9 @@ where
     fn len(&self) -> usize {
         self.heap.len()
     }
+    fn as_slice(&self) -> &[(N, K)] {
+        self.heap.as_slice()
+    }
     fn peek(&self) -> Option<&(N, K)> {
         self.heap.peek()
     }

--- a/orx-priority-queue/src/dary/daryheap_index.rs
+++ b/orx-priority-queue/src/dary/daryheap_index.rs
@@ -35,6 +35,9 @@ where
     fn len(&self) -> usize {
         self.heap.len()
     }
+    fn as_slice(&self) -> &[(N, K)] {
+        self.heap.as_slice()
+    }
     fn peek(&self) -> Option<&(N, K)> {
         self.heap.peek()
     }

--- a/orx-priority-queue/src/dary/daryheap_map.rs
+++ b/orx-priority-queue/src/dary/daryheap_map.rs
@@ -48,6 +48,9 @@ where
     fn len(&self) -> usize {
         self.heap.len()
     }
+    fn as_slice(&self) -> &[(N, K)] {
+        self.heap.as_slice()
+    }
     fn peek(&self) -> Option<&(N, K)> {
         self.heap.peek()
     }

--- a/orx-priority-queue/src/dary/heap.rs
+++ b/orx-priority-queue/src/dary/heap.rs
@@ -169,6 +169,10 @@ where
         self.tree.first()
     }
 
+    fn as_slice(&self) -> &[(N, K)] {
+        &self.tree
+    }
+
     fn clear(&mut self) {
         self.tree.clear();
         self.positions.clear();

--- a/orx-priority-queue/src/priority_queue.rs
+++ b/orx-priority-queue/src/priority_queue.rs
@@ -11,6 +11,11 @@ where
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns the nodes and keys currently in the queue as a slice;
+    /// not necessarily sorted.
+    fn as_slice(&self) -> &[(N, K)];
+
     /// Returns, without popping, a reference to the foremost element of the queue;
     /// returns None if the queue is empty.
     fn peek(&self) -> Option<&(N, K)>;

--- a/orx-priority-queue/tests/daryheap.rs
+++ b/orx-priority-queue/tests/daryheap.rs
@@ -19,6 +19,7 @@ fn test_dary_for<const D: usize>() {
 
     test_len(new_heap());
     test_is_empty(new_heap());
+    test_as_slice(new_heap());
     test_peek(new_heap());
     test_clear(new_heap());
     test_push_pop(new_heap());

--- a/orx-priority-queue/tests/daryheap_4.rs
+++ b/orx-priority-queue/tests/daryheap_4.rs
@@ -20,6 +20,11 @@ fn is_empty() {
 }
 
 #[test]
+fn as_slice() {
+    test_as_slice(new_heap())
+}
+
+#[test]
 fn peek() {
     test_peek(new_heap())
 }

--- a/orx-priority-queue/tests/daryheap_of_indices.rs
+++ b/orx-priority-queue/tests/daryheap_of_indices.rs
@@ -27,6 +27,7 @@ fn test_dary_for<const D: usize>() {
 
     test_len(new_heap());
     test_is_empty(new_heap());
+    test_as_slice(new_heap());
     test_peek(new_heap());
     test_clear(new_heap());
     test_push_pop(new_heap());

--- a/orx-priority-queue/tests/daryheap_of_indices_4.rs
+++ b/orx-priority-queue/tests/daryheap_of_indices_4.rs
@@ -22,6 +22,11 @@ fn is_empty() {
 }
 
 #[test]
+fn as_slice() {
+    test_as_slice(new_heap())
+}
+
+#[test]
 fn peek() {
     test_peek(new_heap())
 }

--- a/orx-priority-queue/tests/daryheap_with_map.rs
+++ b/orx-priority-queue/tests/daryheap_with_map.rs
@@ -27,6 +27,7 @@ fn test_dary_for<const D: usize>() {
 
     test_len(new_heap());
     test_is_empty(new_heap());
+    test_as_slice(new_heap());
     test_peek(new_heap());
     test_clear(new_heap());
     test_push_pop(new_heap());

--- a/orx-priority-queue/tests/daryheap_with_map_4.rs
+++ b/orx-priority-queue/tests/daryheap_with_map_4.rs
@@ -22,6 +22,11 @@ fn is_empty() {
 }
 
 #[test]
+fn as_slice() {
+    test_as_slice(new_heap())
+}
+
+#[test]
 fn peek() {
     test_peek(new_heap())
 }

--- a/orx-priority-queue/tests/priority_queue_tests/as_slice.rs
+++ b/orx-priority-queue/tests/priority_queue_tests/as_slice.rs
@@ -1,0 +1,55 @@
+use itertools::Itertools;
+use orx_priority_queue::PriorityQueue;
+use rand::prelude::*;
+use std::cmp::Ordering;
+
+#[allow(clippy::needless_lifetimes)]
+fn order<'a, 'b>(node_key_1: &'a &(usize, f64), node_key_2: &'b &(usize, f64)) -> Ordering {
+    if node_key_1.1 <= node_key_2.1 {
+        Ordering::Less
+    } else {
+        Ordering::Greater
+    }
+}
+pub fn test_as_slice<P>(mut pq: P)
+where
+    P: PriorityQueue<usize, f64>,
+{
+    const N: usize = 50;
+
+    // fill it up
+    pq.clear();
+    assert!(pq.is_empty());
+    let mut vec = vec![];
+
+    let mut rng = rand::thread_rng();
+    for node in 0..N {
+        let priority = rng.gen();
+        pq.push(node, priority);
+        vec.push((node, priority));
+    }
+
+    // check equality
+    assert_eq!(
+        vec.iter().sorted_by(order).collect_vec(),
+        pq.as_slice().iter().sorted_by(order).collect_vec()
+    );
+
+    // pop half of it
+    for _ in 0..N / 2 {
+        pq.pop();
+        let argmin = vec
+            .iter()
+            .enumerate()
+            .min_by(|x, y| order(&x.1, &y.1))
+            .unwrap()
+            .0;
+        vec.remove(argmin);
+    }
+
+    // check equality
+    assert_eq!(
+        vec.iter().sorted_by(order).collect_vec(),
+        pq.as_slice().iter().sorted_by(order).collect_vec()
+    );
+}

--- a/orx-priority-queue/tests/priority_queue_tests/mod.rs
+++ b/orx-priority-queue/tests/priority_queue_tests/mod.rs
@@ -1,3 +1,4 @@
+mod as_slice;
 mod clear;
 mod is_empty;
 mod len;
@@ -5,6 +6,7 @@ mod peek;
 mod push_pop;
 mod push_then_pop;
 
+pub use as_slice::test_as_slice;
 pub use clear::test_clear;
 pub use is_empty::test_is_empty;
 pub use len::test_len;


### PR DESCRIPTION
`as_slice` exposes the underlying (node, key) data of the priority queue without any promise on the slice to be sorted.

While it is useful to expose the current elements of a queue, there must not be any `as_mut_slice` method.

* The trait method is defined.
* dary-heap implementations are provided and tested.