### PR TITLE
special traversal for binary heap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-priority-queue"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["orxfun"]
 description = "Priority queue traits and generalized d-ary heap implementations."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ca# orx-priority-queue
+# orx-priority-queue
 Priority queue traits; binary and generalized d-ary heap implementations.
 
 ## Traits
@@ -31,7 +31,7 @@ are often made available through usage of additional memory.
 
 ## Implementations
 
-### d-ary Heap
+### d-ary heap
 
 The core [d-ary heap](https://en.wikipedia.org/wiki/D-ary_heap) is implemented thanks to const generics.
 Three structs are created from this core struct:
@@ -43,6 +43,17 @@ This might be considered as the default way to extend the heap to enable additio
 * `DaryHeapOfIndices<N, K, const D: usize>` where `N: HasIndex` which implements `PriorityQueueDecKey<N, K>: PriorityQueue<N, K>`.
 This variant is and alternative to the hash-map extention and is particularly useful in algorithms where nodes to be enqueued are sampled from a closed set with known elements
 and the size of the queue is likely to get close to total number of candidates.
+
+### Special traversal for d=2: binary-heap
+
+const generics further allows to use special arithmetics for the special case where d=2; i.e.,
+when d-ary heap is the binary heap.
+In particular, one addition/subtraction is avoided during the traversal through the tree.
+
+However, overall performance of the queues depends on the use case,
+ratio of push an decrease-key operations, etc.
+Benchmarks will follow.
+
 
 ## Example
 

--- a/src/dary/daryheap.rs
+++ b/src/dary/daryheap.rs
@@ -17,10 +17,7 @@ where
 {
     fn default() -> Self {
         Self {
-            heap: Heap {
-                tree: Vec::new(),
-                positions: HeapPositionsNone,
-            },
+            heap: Heap::new(None, HeapPositionsNone),
         }
     }
 }
@@ -31,10 +28,7 @@ where
 {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            heap: Heap {
-                tree: Vec::with_capacity(capacity),
-                positions: HeapPositionsNone,
-            },
+            heap: Heap::new(Some(capacity), HeapPositionsNone),
         }
     }
 }

--- a/src/dary/daryheap_const_helpers.rs
+++ b/src/dary/daryheap_const_helpers.rs
@@ -1,0 +1,45 @@
+use std::mem::MaybeUninit;
+
+pub(crate) fn init_tree<N, K>(capacity: Option<usize>) -> Vec<(N, K)> {
+    match capacity {
+        Some(c) => Vec::with_capacity(c),
+        None => vec![],
+    }
+}
+
+/// # SAFETY
+/// In order to avoid certain arithmetic operations, the first offset number of entries of the tree are skipped.
+/// `tree` is a private field and none of the methods access the element at 0; hence, the offset will never be read.
+/// The tree is kept private and the offset entries are never accessed.
+pub(crate) unsafe fn add_offset_to_tree<N, K, const D: usize>(tree: &mut Vec<(N, K)>) {
+    let offset = offset::<D>();
+    for _ in 0..offset {
+        let uninit_offset = MaybeUninit::<(N, K)>::uninit();
+        let offset_value = uninit_offset.assume_init();
+        tree.push(offset_value);
+    }
+}
+pub(crate) const fn offset<const D: usize>() -> usize {
+    match D {
+        2 => 1,
+        _ => 0,
+    }
+}
+pub(crate) const fn parent_of<const D: usize>(child: usize) -> usize {
+    match D {
+        2 => child >> 1,
+        4 => (child - 1) >> 2,
+        8 => (child - 1) >> 3,
+        16 => (child - 1) >> 4,
+        _ => (child - 1) / D,
+    }
+}
+pub(crate) const fn child_of<const D: usize>(parent: usize) -> usize {
+    match D {
+        2 => parent << 1,
+        4 => (parent << 2) + 1,
+        8 => (parent << 3) + 1,
+        16 => (parent << 4) + 1,
+        _ => D * parent + 1,
+    }
+}

--- a/src/dary/daryheap_index.rs
+++ b/src/dary/daryheap_index.rs
@@ -19,10 +19,10 @@ where
 {
     pub fn with_upper_limit(upper_limit: usize) -> Self {
         Self {
-            heap: Heap {
-                tree: Vec::with_capacity(upper_limit),
-                positions: HeapPositionsHasIndex::with_upper_limit(upper_limit),
-            },
+            heap: Heap::new(
+                Some(upper_limit),
+                HeapPositionsHasIndex::with_upper_limit(upper_limit),
+            ),
         }
     }
 }

--- a/src/dary/daryheap_map.rs
+++ b/src/dary/daryheap_map.rs
@@ -18,10 +18,7 @@ where
 {
     fn default() -> Self {
         Self {
-            heap: Heap {
-                tree: Vec::new(),
-                positions: HeapPositionsMap::default(),
-            },
+            heap: Heap::new(None, HeapPositionsMap::default()),
         }
     }
 }
@@ -32,10 +29,7 @@ where
 {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            heap: Heap {
-                tree: Vec::with_capacity(capacity),
-                positions: HeapPositionsMap::with_capacity(capacity),
-            },
+            heap: Heap::new(Some(capacity), HeapPositionsMap::with_capacity(capacity)),
         }
     }
 }

--- a/src/dary/mod.rs
+++ b/src/dary/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod daryheap;
+mod daryheap_const_helpers;
 pub(crate) mod daryheap_index;
 pub(crate) mod daryheap_map;
 mod heap;

--- a/tests/daryheap.rs
+++ b/tests/daryheap.rs
@@ -5,13 +5,15 @@ use priority_queue_tests::*;
 
 #[test]
 fn test_dary_forall() {
-    test_dary_for::<2>();
-    test_dary_for::<3>();
-    test_dary_for::<4>();
-    test_dary_for::<7>();
-    test_dary_for::<8>();
-    test_dary_for::<13>();
-    test_dary_for::<16>();
+    for _ in 0..100 {
+        test_dary_for::<2>();
+        test_dary_for::<3>();
+        test_dary_for::<4>();
+        test_dary_for::<7>();
+        test_dary_for::<8>();
+        test_dary_for::<13>();
+        test_dary_for::<16>();
+    }
 }
 
 fn test_dary_for<const D: usize>() {

--- a/tests/daryheap_2.rs
+++ b/tests/daryheap_2.rs
@@ -1,0 +1,54 @@
+mod priority_queue_tests;
+
+use orx_priority_queue::DaryHeap;
+use priority_queue_tests::*;
+
+const D: usize = 2;
+
+fn new_heap() -> DaryHeap<usize, f64, D> {
+    DaryHeap::default()
+}
+
+#[test]
+fn len() {
+    test_len(new_heap())
+}
+
+#[test]
+fn is_empty() {
+    test_is_empty(new_heap())
+}
+
+#[test]
+fn as_slice() {
+    test_as_slice(new_heap())
+}
+
+#[test]
+fn peek() {
+    test_peek(new_heap())
+}
+
+#[test]
+fn clear() {
+    test_clear(new_heap())
+}
+
+#[test]
+fn push_pop() {
+    test_push_pop(new_heap())
+}
+
+#[test]
+fn push_pop_randomized() {
+    test_push_pop_randomized(new_heap())
+}
+
+#[test]
+fn push_then_pop() {
+    test_push_then_pop(new_heap())
+}
+#[test]
+fn push_then_pop_randomized() {
+    test_push_then_pop_randomized(new_heap())
+}

--- a/tests/daryheap_of_indices.rs
+++ b/tests/daryheap_of_indices.rs
@@ -7,13 +7,15 @@ use priority_queue_tests::*;
 
 #[test]
 fn test_dary_forall() {
-    test_dary_for::<2>();
-    test_dary_for::<3>();
-    test_dary_for::<4>();
-    test_dary_for::<7>();
-    test_dary_for::<8>();
-    test_dary_for::<13>();
-    test_dary_for::<16>();
+    for _ in 0..100 {
+        test_dary_for::<2>();
+        test_dary_for::<3>();
+        test_dary_for::<4>();
+        test_dary_for::<7>();
+        test_dary_for::<8>();
+        test_dary_for::<13>();
+        test_dary_for::<16>();
+    }
 }
 
 fn test_dary_for<const D: usize>() {

--- a/tests/daryheap_of_indices_2.rs
+++ b/tests/daryheap_of_indices_2.rs
@@ -1,0 +1,101 @@
+mod priority_queue_deckey_tests;
+mod priority_queue_tests;
+
+use orx_priority_queue::DaryHeapOfIndices;
+use priority_queue_deckey_tests::*;
+use priority_queue_tests::*;
+
+const D: usize = 2;
+
+fn new_heap() -> DaryHeapOfIndices<usize, f64, D> {
+    DaryHeapOfIndices::with_upper_limit(125)
+}
+
+#[test]
+fn len() {
+    test_len(new_heap())
+}
+
+#[test]
+fn is_empty() {
+    test_is_empty(new_heap())
+}
+
+#[test]
+fn as_slice() {
+    test_as_slice(new_heap())
+}
+
+#[test]
+fn peek() {
+    test_peek(new_heap())
+}
+
+#[test]
+fn clear() {
+    test_clear(new_heap())
+}
+
+#[test]
+fn push_pop() {
+    test_push_pop(new_heap())
+}
+
+#[test]
+fn push_pop_randomized() {
+    test_push_pop_randomized(new_heap())
+}
+
+#[test]
+fn push_then_pop() {
+    test_push_then_pop(new_heap())
+}
+#[test]
+fn push_then_pop_randomized() {
+    test_push_then_pop_randomized(new_heap())
+}
+
+#[test]
+fn contains() {
+    test_contains(new_heap());
+}
+
+#[test]
+fn key_of() {
+    test_key_of(new_heap());
+}
+
+#[test]
+fn decrease_key() {
+    test_change_key(new_heap(), ChangeKeyMethod::Decrease);
+}
+
+#[test]
+fn update_key() {
+    test_change_key(new_heap(), ChangeKeyMethod::Update);
+}
+
+#[test]
+fn try_decrease_key() {
+    test_change_key(new_heap(), ChangeKeyMethod::TryDecrease);
+}
+
+#[test]
+fn remove() {
+    test_remove(new_heap());
+}
+
+#[test]
+fn decrease_key_or_push() {
+    test_change_key_or_push(new_heap(), ChangeKeyMethod::Decrease);
+}
+
+#[test]
+fn update_key_or_push() {
+    test_change_key_or_push(new_heap(), ChangeKeyMethod::Update);
+}
+
+#[test]
+fn try_decrease_key_or_push() {
+    test_change_key_or_push(new_heap(), ChangeKeyMethod::TryDecrease);
+}

--- a/tests/daryheap_with_map.rs
+++ b/tests/daryheap_with_map.rs
@@ -7,13 +7,15 @@ use priority_queue_tests::*;
 
 #[test]
 fn test_dary_forall() {
-    test_dary_for::<2>();
-    test_dary_for::<3>();
-    test_dary_for::<4>();
-    test_dary_for::<7>();
-    test_dary_for::<8>();
-    test_dary_for::<13>();
-    test_dary_for::<16>();
+    for _ in 0..100 {
+        test_dary_for::<2>();
+        test_dary_for::<3>();
+        test_dary_for::<4>();
+        test_dary_for::<7>();
+        test_dary_for::<8>();
+        test_dary_for::<13>();
+        test_dary_for::<16>();
+    }
 }
 
 fn test_dary_for<const D: usize>() {

--- a/tests/daryheap_with_map_2.rs
+++ b/tests/daryheap_with_map_2.rs
@@ -1,0 +1,106 @@
+mod priority_queue_deckey_tests;
+mod priority_queue_tests;
+
+use orx_priority_queue::DaryHeapWithMap;
+use priority_queue_deckey_tests::*;
+use priority_queue_tests::*;
+
+const D: usize = 2;
+
+fn new_heap() -> DaryHeapWithMap<usize, f64, D> {
+    DaryHeapWithMap::default()
+}
+
+#[test]
+fn len() {
+    test_len(new_heap())
+}
+
+#[test]
+fn is_empty() {
+    test_is_empty(new_heap())
+}
+
+#[test]
+fn as_slice() {
+    test_as_slice(new_heap())
+}
+
+#[test]
+fn peek() {
+    test_peek(new_heap())
+}
+
+#[test]
+fn clear() {
+    test_clear(new_heap())
+}
+
+#[test]
+fn push_pop() {
+    test_push_pop(new_heap())
+}
+
+#[test]
+fn push_pop_randomized() {
+    test_push_pop_randomized(new_heap())
+}
+
+#[test]
+fn push_then_pop() {
+    test_push_then_pop(new_heap())
+}
+#[test]
+fn push_then_pop_randomized() {
+    test_push_then_pop_randomized(new_heap())
+}
+
+#[test]
+fn contains() {
+    test_contains(new_heap());
+}
+
+#[test]
+fn key_of() {
+    test_key_of(new_heap());
+}
+
+#[test]
+fn decrease_key() {
+    test_change_key(new_heap(), ChangeKeyMethod::Decrease);
+}
+
+#[test]
+fn update_key() {
+    test_change_key(new_heap(), ChangeKeyMethod::Update);
+}
+
+#[test]
+fn try_decrease_key() {
+    test_change_key(new_heap(), ChangeKeyMethod::TryDecrease);
+}
+
+#[test]
+fn remove() {
+    test_remove(new_heap());
+}
+
+#[test]
+fn decrease_key_or_push() {
+    test_change_key_or_push(new_heap(), ChangeKeyMethod::Decrease);
+}
+
+#[test]
+fn update_key_or_push() {
+    test_change_key_or_push(new_heap(), ChangeKeyMethod::Update);
+}
+
+#[test]
+fn try_decrease_key_or_push() {
+    test_change_key_or_push(new_heap(), ChangeKeyMethod::TryDecrease);
+}
+
+#[test]
+fn as_slice_mappo() {
+    test_as_slice(new_heap())
+}


### PR DESCRIPTION
The tree is offset by one uninitialized element when d=2; i.e., the d-ary heap is the binary heap.

This allows one less arithmetic operation while computing the parent and left-most child nodes of a node on the tree.