### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["orxfun"]
 description = "Priority queue traits and generalized d-ary heap implementations."
 license = "MIT"
-
+repository = "https://github.com/orxfun/orx-priority-queue/"
 
 [dependencies]
 


### PR DESCRIPTION
to allow crates.io to link back