### PR TITLE
Add no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/orxfun/orx-priority-queue/"
 keywords = ["priority", "queue", "heap", "dary", "binary"]
 categories = ["data-structures"]
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/src/dary/daryheap_const_helpers.rs
+++ b/src/dary/daryheap_const_helpers.rs
@@ -1,4 +1,6 @@
-use std::mem::MaybeUninit;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 pub(crate) fn init_tree<N, K>(capacity: Option<usize>) -> Vec<(N, K)> {
     match capacity {

--- a/src/dary/daryheap_map.rs
+++ b/src/dary/daryheap_map.rs
@@ -1,6 +1,8 @@
 use super::heap::Heap;
-use crate::{positions::map::HeapPositionsMap, PriorityQueue, PriorityQueueDecKey};
-use std::hash::Hash;
+use crate::{
+    positions::map::{HeapPositionsMap, Index},
+    PriorityQueue, PriorityQueueDecKey,
+};
 
 /// Type alias for `DaryHeapWithMap<N, K, 2>`; see [`DaryHeapWithMap`] for details.
 pub type BinaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 2>;
@@ -29,7 +31,7 @@ pub type QuarternaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 4>;
 ///     P: PriorityQueue<usize, f64>
 /// {
 ///     pq.clear();
-///     
+///
 ///     pq.push(0, 42.0);
 ///     assert_eq!(Some(&(0, 42.0)), pq.peek());
 ///
@@ -69,7 +71,7 @@ pub type QuarternaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 4>;
 ///     P: PriorityQueueDecKey<usize, f64>
 /// {
 ///     pq.clear();
-///     
+///
 ///     pq.push(0, 42.0);
 ///     assert_eq!(Some(&(0, 42.0)), pq.peek());
 ///
@@ -104,7 +106,7 @@ pub type QuarternaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 4>;
 #[derive(Debug, Clone)]
 pub struct DaryHeapWithMap<N, K, const D: usize = 2>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     heap: Heap<N, K, HeapPositionsMap<N>, D>,
@@ -112,7 +114,7 @@ where
 
 impl<N, K, const D: usize> Default for DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     fn default() -> Self {
@@ -123,7 +125,7 @@ where
 }
 impl<N, K, const D: usize> DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     /// Creates a new d-ary heap with the given initial `capacity` on the number of nodes to simultaneously exist on the heap.
@@ -136,7 +138,7 @@ where
 
 impl<N, K, const D: usize> PriorityQueue<N, K> for DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     fn len(&self) -> usize {
@@ -174,7 +176,7 @@ where
 }
 impl<N, K, const D: usize> PriorityQueueDecKey<N, K> for DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     fn contains(&self, node: &N) -> bool {

--- a/src/dary/heap.rs
+++ b/src/dary/heap.rs
@@ -3,6 +3,7 @@ use crate::{
     positions::heap_positions::{HeapPositions, HeapPositionsDecKey},
     PriorityQueue, PriorityQueueDecKey,
 };
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Heap<N, K, P, const D: usize>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,9 @@
     clippy::missing_panics_doc,
     clippy::todo
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod dary;
 mod has_index;

--- a/src/positions/has_index.rs
+++ b/src/positions/has_index.rs
@@ -1,6 +1,8 @@
 use super::heap_positions::{HeapPositions, HeapPositionsDecKey};
 use crate::HasIndex;
-use std::marker::PhantomData;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 /// using usize::MAX as None
 const NONE: usize = usize::MAX;

--- a/src/positions/map.rs
+++ b/src/positions/map.rs
@@ -1,36 +1,56 @@
 use super::heap_positions::{HeapPositions, HeapPositionsDecKey};
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
 use std::{collections::HashMap, hash::Hash};
+
+#[cfg(not(feature = "std"))]
+pub trait Index: Eq + Clone + Ord {}
+#[cfg(not(feature = "std"))]
+impl<T> Index for T where T: Eq + Clone + Ord {}
+#[cfg(feature = "std")]
+pub trait Index: Eq + Clone + Hash {}
+#[cfg(feature = "std")]
+impl<T> Index for T where T: Eq + Clone + Hash {}
+
+#[cfg(not(feature = "std"))]
+type Map<N> = BTreeMap<N, usize>;
+#[cfg(feature = "std")]
+type Map<N> = HashMap<N, usize>;
 
 #[derive(Clone, Debug)]
 pub struct HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
-    map: HashMap<N, usize>,
+    map: Map<N>,
 }
 impl<N> Default for HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
     fn default() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
+        Self { map: Map::new() }
     }
 }
 impl<N> HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
+    #[allow(unused)]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            map: HashMap::with_capacity(capacity),
+            #[cfg(not(std))]
+            map: Map::new(),
+            #[cfg(std)]
+            map: Map::with_capacity(capacity),
         }
     }
 }
 impl<N> HeapPositions<N> for HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
     fn clear(&mut self) {
         self.map.clear();
@@ -72,4 +92,4 @@ where
     }
 }
 
-impl<N> HeapPositionsDecKey<N> for HeapPositionsMap<N> where N: Eq + Hash + Clone {}
+impl<N> HeapPositionsDecKey<N> for HeapPositionsMap<N> where N: Index {}


### PR DESCRIPTION
Using `BTreeMap` instead of `HashMap` and changing a couple imports from `std` to their `core` and `alloc` counterparts, this crate can be used in `no_std` environments.

Since `BTreeMap` requires `Ord` instead of `Hash`, I added a trait that's implemented for either depending on the `std` feature.

An alternative to `BTreeMap` would be using `hashbrown::HashMap` but `BTreeMap` seems to be a common replacement. I haven't run a benchmark to compare the performance impact here.