### PR TITLE
const-generics improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/orxfun/orx-priority-queue/"
 keywords = ["priority", "queue", "heap", "dary", "binary"]
 categories = ["data-structures"]
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-priority-queue"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "Priority queue traits, d-ary heap implementations having binary heap as a special case."
@@ -9,8 +9,6 @@ repository = "https://github.com/orxfun/orx-priority-queue/"
 keywords = ["priority", "queue", "heap", "dary", "binary"]
 categories = ["data-structures"]
 
-[dependencies]
-
 [dev-dependencies]
-itertools = "0.11.0"
-rand = "0.8.5"
+itertools = "0.11"
+rand = "0.8"

--- a/src/dary/daryheap.rs
+++ b/src/dary/daryheap.rs
@@ -97,6 +97,11 @@ where
             heap: Heap::new(Some(capacity), HeapPositionsNone),
         }
     }
+    /// Returns the 'd' of the d-ary heap.
+    /// In other words, it represents the maximum number of children that each node on the heap can have.
+    pub const fn d() -> usize {
+        D
+    }
 }
 
 impl<N, K, const D: usize> PriorityQueue<N, K> for DaryHeap<N, K, D>
@@ -104,8 +109,13 @@ where
     N: Clone,
     K: PartialOrd + Clone,
 {
+    #[inline(always)]
     fn len(&self) -> usize {
         self.heap.len()
+    }
+    #[inline(always)]
+    fn capacity(&self) -> usize {
+        self.heap.capacity()
     }
     fn as_slice(&self) -> &[(N, K)] {
         self.heap.as_slice()
@@ -116,18 +126,23 @@ where
     fn clear(&mut self) {
         self.heap.clear()
     }
+    #[inline(always)]
     fn pop(&mut self) -> Option<(N, K)> {
         self.heap.pop()
     }
+    #[inline(always)]
     fn pop_node(&mut self) -> Option<N> {
         self.heap.pop_node()
     }
+    #[inline(always)]
     fn pop_key(&mut self) -> Option<K> {
         self.heap.pop_key()
     }
+    #[inline(always)]
     fn push(&mut self, node: N, key: K) {
         self.heap.push(node, key)
     }
+    #[inline(always)]
     fn push_then_pop(&mut self, node: N, key: K) -> (N, K) {
         self.heap.push_then_pop(node, key)
     }

--- a/src/dary/daryheap_const_helpers.rs
+++ b/src/dary/daryheap_const_helpers.rs
@@ -1,4 +1,6 @@
-use std::mem::MaybeUninit;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 pub(crate) fn init_tree<N, K>(capacity: Option<usize>) -> Vec<(N, K)> {
     match capacity {

--- a/src/dary/daryheap_const_helpers.rs
+++ b/src/dary/daryheap_const_helpers.rs
@@ -19,27 +19,57 @@ pub(crate) unsafe fn add_offset_to_tree<N, K, const D: usize>(tree: &mut Vec<(N,
         tree.push(offset_value);
     }
 }
+/// when `D` = 2^k
+/// * offset = 2^k-1
+///
+/// otherwise
+/// * offset = 0
 pub(crate) const fn offset<const D: usize>() -> usize {
     match D {
         2 => 1,
+        4 => 3,
+        8 => 7,
+        16 => 15,
+        32 => 31,
+        64 => 63,
         _ => 0,
     }
 }
+/// Let c = `child`.
+///
+/// when `D` = 2^k
+/// * parent_offset = 2^k - 2
+/// * parent = c / 2^k + parent_offset
+///
+/// otherwise
+/// * parent = (c - 1) / `D`
 pub(crate) const fn parent_of<const D: usize>(child: usize) -> usize {
     match D {
         2 => child >> 1,
-        4 => (child - 1) >> 2,
-        8 => (child - 1) >> 3,
-        16 => (child - 1) >> 4,
+        4 => (child >> 2) + 2,
+        8 => (child >> 3) + 6,
+        16 => (child >> 4) + 14,
+        32 => (child >> 5) + 30,
+        64 => (child >> 6) + 62,
         _ => (child - 1) / D,
     }
 }
-pub(crate) const fn child_of<const D: usize>(parent: usize) -> usize {
+/// Let p = `parent`.
+///
+/// when `D` = 2^k
+/// * parent_offset = 2^k - 2
+/// * left_child = p * 2^k - parent_offset * 2^k
+///
+/// otherwise
+/// * left_child = `D` * parent + 1
+pub(crate) const fn left_child_of<const D: usize>(parent: usize) -> usize {
     match D {
         2 => parent << 1,
-        4 => (parent << 2) + 1,
-        8 => (parent << 3) + 1,
-        16 => (parent << 4) + 1,
+        4 => (parent << 2) - 8,
+        8 => (parent << 3) - 48,
+        16 => (parent << 4) - 224,
+        32 => (parent << 5) - 960,
+        64 => (parent << 6) - 3968,
         _ => D * parent + 1,
     }
 }

--- a/src/dary/daryheap_map.rs
+++ b/src/dary/daryheap_map.rs
@@ -1,6 +1,8 @@
 use super::heap::Heap;
-use crate::{positions::map::HeapPositionsMap, PriorityQueue, PriorityQueueDecKey};
-use std::hash::Hash;
+use crate::{
+    positions::map::{HeapPositionsMap, Index},
+    PriorityQueue, PriorityQueueDecKey,
+};
 
 /// Type alias for `DaryHeapWithMap<N, K, 2>`; see [`DaryHeapWithMap`] for details.
 pub type BinaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 2>;
@@ -29,7 +31,7 @@ pub type QuarternaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 4>;
 ///     P: PriorityQueue<usize, f64>
 /// {
 ///     pq.clear();
-///     
+///
 ///     pq.push(0, 42.0);
 ///     assert_eq!(Some(&(0, 42.0)), pq.peek());
 ///
@@ -69,7 +71,7 @@ pub type QuarternaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 4>;
 ///     P: PriorityQueueDecKey<usize, f64>
 /// {
 ///     pq.clear();
-///     
+///
 ///     pq.push(0, 42.0);
 ///     assert_eq!(Some(&(0, 42.0)), pq.peek());
 ///
@@ -104,7 +106,7 @@ pub type QuarternaryHeapWithMap<N, K> = DaryHeapWithMap<N, K, 4>;
 #[derive(Debug, Clone)]
 pub struct DaryHeapWithMap<N, K, const D: usize = 2>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     heap: Heap<N, K, HeapPositionsMap<N>, D>,
@@ -112,7 +114,7 @@ where
 
 impl<N, K, const D: usize> Default for DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     fn default() -> Self {
@@ -123,7 +125,7 @@ where
 }
 impl<N, K, const D: usize> DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     /// Creates a new d-ary heap with the given initial `capacity` on the number of nodes to simultaneously exist on the heap.
@@ -136,7 +138,7 @@ where
 
 impl<N, K, const D: usize> PriorityQueue<N, K> for DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     fn len(&self) -> usize {
@@ -174,7 +176,7 @@ where
 }
 impl<N, K, const D: usize> PriorityQueueDecKey<N, K> for DaryHeapWithMap<N, K, D>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
     K: PartialOrd + Clone,
 {
     fn contains(&self, node: &N) -> bool {

--- a/src/dary/heap.rs
+++ b/src/dary/heap.rs
@@ -3,6 +3,7 @@ use crate::{
     positions::heap_positions::{HeapPositions, HeapPositionsDecKey},
     PriorityQueue, PriorityQueueDecKey,
 };
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Heap<N, K, P, const D: usize>

--- a/src/dary/heap.rs
+++ b/src/dary/heap.rs
@@ -1,10 +1,12 @@
-use super::daryheap_const_helpers::{add_offset_to_tree, child_of, init_tree, offset, parent_of};
+use super::daryheap_const_helpers::{
+    add_offset_to_tree, init_tree, left_child_of, offset, parent_of,
+};
 use crate::{
     positions::heap_positions::{HeapPositions, HeapPositionsDecKey},
-    PriorityQueue, PriorityQueueDecKey,
+    PriorityQueue, PriorityQueueDecKey, ResUpdateKey,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Heap<N, K, P, const D: usize>
 where
     N: Clone,
@@ -63,7 +65,7 @@ where
         let tree_len = self.tree.len();
 
         let mut parent = starting_position;
-        let first_child = child_of::<D>(starting_position);
+        let first_child = left_child_of::<D>(starting_position);
         if first_child >= tree_len {
             return;
         }
@@ -94,7 +96,7 @@ where
             self.tree[parent] = self.tree[best_child].clone();
 
             parent = best_child;
-            let first_child = child_of::<D>(parent);
+            let first_child = left_child_of::<D>(parent);
             if first_child >= tree_len {
                 break;
             }
@@ -156,6 +158,9 @@ where
     }
     fn is_empty(&self) -> bool {
         self.tree.len() == offset::<D>()
+    }
+    fn capacity(&self) -> usize {
+        self.tree.capacity() - offset::<D>()
     }
 
     fn peek(&self) -> Option<&(N, K)> {
@@ -239,7 +244,7 @@ where
                 K: PartialOrd,
             {
                 for i in 0..D {
-                    let child = child_of::<D>(parent) + i;
+                    let child = left_child_of::<D>(parent) + i;
                     if child >= tree.len() {
                         return true;
                     } else if tree[child].1 < tree[parent].1 {
@@ -272,31 +277,31 @@ where
             .position_of(node)
             .map(|i| self.tree[i].1.clone())
     }
-    fn decrease_key(&mut self, node: &N, decreased_key: &K) {
+    fn decrease_key(&mut self, node: &N, decreased_key: K) {
         let position = self
             .positions
             .position_of(node)
             .expect("cannot decrease key of a node that is not on the queue");
         assert!(
-            decreased_key <= &self.tree[position].1,
+            decreased_key <= self.tree[position].1,
             "decrease_key is called with a greater key"
         );
         self.tree[position].1 = decreased_key.clone();
         self.heapify_up(position);
     }
-    fn update_key(&mut self, node: &N, new_key: &K) -> bool {
+    fn update_key(&mut self, node: &N, new_key: K) -> ResUpdateKey {
         let position = self
             .positions
             .position_of(node)
             .expect("cannot update key of a node that is not on the queue");
-        let up = new_key < &self.tree[position].1;
+        let up = new_key < self.tree[position].1;
         self.tree[position].1 = new_key.clone();
         if up {
             self.heapify_up(position);
-            true
+            ResUpdateKey::Decreased
         } else {
             self.heapify_down(position);
-            false
+            ResUpdateKey::Increased
         }
     }
 

--- a/src/has_index.rs
+++ b/src/has_index.rs
@@ -16,26 +16,31 @@ pub trait HasIndex: Clone {
 }
 
 impl HasIndex for usize {
+    #[inline(always)]
     fn index(&self) -> usize {
         *self
     }
 }
 impl HasIndex for u64 {
+    #[inline(always)]
     fn index(&self) -> usize {
         *self as usize
     }
 }
 impl HasIndex for u32 {
+    #[inline(always)]
     fn index(&self) -> usize {
         *self as usize
     }
 }
 impl HasIndex for u16 {
+    #[inline(always)]
     fn index(&self) -> usize {
         *self as usize
     }
 }
 impl HasIndex for u8 {
+    #[inline(always)]
     fn index(&self) -> usize {
         *self as usize
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,206 +1,57 @@
-//! Priority queue traits, d-ary heap implementations having binary heap as a special case.
+//! # orx-priority-queue
+//!
+//! This crate aims to address the following:
+//!
+//! 1. To provide priority queue traits for two goals:
+//!     * to separate simple and decrease key queues, and
+//!     * to enable developing functions or algorithms which are generic over the actual queue type.
+//! 2. To provide d-ary heap implementations, which is generic over `d`:
+//!     * the implementation makes use of the const-generics which conveniently allows to take advantage of bit operations for the cases where `d` is a power of two, while having a general implementation for others.
+//!
 //!
 //! ## Traits
 //!
 //! This crate defines two priority queue traits for (node, key) pairs with the following features:
 //!
-//! * [`PriorityQueue<N, K>`]: providing basic priority queue functionalities.
-//! * [`PriorityQueueDecKey<N, K>`]: adds super powers which is achieved by being able to locate positions of nodes that already exists on the heap.
+//! * `PriorityQueue<N, K>`: providing basic priority queue functionalities.
+//! * `PriorityQueueDecKey<N, K>`: extends the `PriorityQueue` by allowing methods to mutate keys of existing items.
 //!
-//! Separating more advanced `PriorityQueueDecKey` from the basic queue is due to the fact that additional functionalities are often made available through usage of additional memory.
+//! The differences can be summarized as follows:
 //!
-//! ### Benefits of `PriorityQueueDecKey`
+//! * A decrease key queue is also a simple priority queue; with additonal operations such as `decrease_key` and `update_key`, etc.
+//! * A simple queue has a lower initial memory requirement; while the decrease key queues need an additional internal data structure to keep track of positions.
+//! * On the other hand, a decrease key queue provides a better space complexity than a simple queue in many algorithms.
+//!     * For instance, a Dijkstra's shortest path algorithm implementation with a simple queue has a space complexity of O(n^2) due to the fact that every node can enter the node n times, where n is the number of nodes.
+//!     * However, the same algorithm using a decrease key queue requires a space complexity of O(n) since each node will enter the queue at most once, and its key will be updated if the same node is observed more than once.
 //!
-//! Decrease-key, and related operations, are critical for certain algorithms where the key of a particular node is evaluated multiple times. Without the ability to update keys of nodes on the heap, space complexity of correspoinding algorithms
-//! increases exponentially.
+//! ## Choice of the Queue
 //!
-//! Consider Dijkstra's shortest-path algorithm for instance. Space complexity of the algorithm would be *O(n^2)* with a `PriorityQueue` where *n* is the number of nodes on the graph. This is due to the fact that label of each node might be evaluated *n-1* times and consequently each node can be pushed to the queue *n-1* times. As also noted in `std::collections::BinaryHeap` documentation, [*this implementation isn't memory-efficient as it may leave duplicate nodes in the queue.*](https://doc.rust-lang.org/stable/std/collections/binary_heap/index.html)
+//! This crate provides three kinds of queue implementations. You may find below their differences and the situations each could be a better fit.
 //!
-//! On the other hand, using a `PriorityQueueDecKey`, space complexity of the algorithm will be kept as *O(n)*: each node will enter the queue at most once; consequent evaluations of its label will be handled by decrease key operation.
+//! * `OrxDaryHeap` is a simple `PriorityQueue` implemented as a heap.
+//!     * Benefits from its simplicity.
+//!     * Could be considered as the default queue implementation where the memory efficiency is not very critical.
+//! * `OrxDaryHeapOfIndices` is a `PriorityQueueDecKey` which aims to be performant while requiring the items that can enter the queue to implement `HasIndex` trait, which simply has the single method `fn index(&self) -> usize`. The implementation is a heap parallel to a mapping of items to positions on the heap.
+//!     * Particularly useful in performance critical algorithms which additionally requires memory efficiency.
+//!     * Requires that the size of the closed set of candidates that can enter the queue is known. This is not a strong limitation in many algorithms. For instance, for most network traversal algorithms, this equals to the number of nodes in the graph.
+//! * `OrxDaryHeapWithMap` is also a `PriorityQueueDecKey` which aims to be flexible requiring the items to implement `Hash + Eq`. It has a similar implementation with the prior except that it utilizes a map to keep track of item positions on the heap.
+//!     * This can be considered as the alternative to `OrxDaryHeapOfIndices` in memory critical situations, where it is not possible to satisfy the requirement on knowing the size of the closed set of candidates.
 //!
-//! Furthermore, the additional functionalities simplify the algorithm implementation pushing some of the complexity to the data structure. This becomes clear when the following `shortest_path` implementation is compared to the corresponding `std::collections::BinaryHeap` example. Note that it is almost a direct substitution while providing a better space complexity, generic dary-heap options and a cleaner algorithm implementation.
+//! Note that each of the above kinds is generic over `d`, leading to a large number of possible queue choices. The traits come handy here allowing to write algorithms generic over the queue, which then can be benchmarked with different concrete types to find the most performant implementation for the problem. In the next section, we summarize such an experiment.
 //!
+//! ### Experiments on Shortest Path Algorithm
 //!
-//! #### `PriorityQueue` version of Dijkstra's shortest path algorithm
+//! Using the traits, we can write algorithms which are generic over the queues. This allows to conveniently benchmark over the relevant data to find the best fitting queue implementation. You may see such an example exercise in the repository [https://github.com/orxfun/orx-bench-shortest-path](https://github.com/orxfun/orx-bench-shortest-path) which allows to compare different shortest path algorithm implementations. From our current experiments using random and real life networks, the following table can be consulted.
 //!
-//! Below is the main iteration of Dijkstra's shortest path algorithm with a basic priority queue without a decrease key operation; taken and slightly adjusted from `std::collections::BinaryHeap`.
-//!
-//! ```rust ignore
-//! // Examine the frontier with lower cost nodes first (min-heap)
-//! while let Some((position, cost)) = heap.pop() {
-//!     // Alternatively we could have continued to find all shortest paths
-//!     if position == goal {
-//!         return Some(cost);
-//!     }
-//!
-//!     // Important as we may have already found a better way
-//!     if cost > dist[position] { continue; }
-//!
-//!     // For each node we can reach, see if we can find a way with
-//!     // a lower cost going through this node
-//!     for edge in &adj_list[position] {
-//!         let next = State { cost: cost + edge.cost, position: edge.node };
-//!
-//!         // If so, add it to the frontier and continue
-//!         if next.cost < dist[next.position] {
-//!             heap.push(next);
-//!             // Relaxation, we have now found a better way
-//!             dist[next.position] = next.cost;
-//!         }
-//!     }
-//! }
-//! ```
-//!
-//! In addition to the heap, we need to keep the `dist` array. This has two main purposes:
-//! * to avoid visiting the same node multiple times by the check `cost > dist[position]`;
-//! * so that we do not push non-improving labels to the queue to reduce heap pushes by `next.cost < dist[next.position]`; however, it still requires *O(n^2)* space complexity.
-//!
-//! Notice that none of these would be necessary if each node entered the heap at most once and its key was updated throughout the search whenever a shorter path is found.
-//!
-//! #### `PriorityQueueDecKey` version of Dijkstra's shortest path algorithm
-//!
-//! See below the `PriorityQueueDecKey` version which reduces space complexity to *O(n)*.
-//!
-//! The heap is now internally paired up with a positions array (`DaryHeapOfIndices`) or hash map (`DaryHeapWithMap`) with space complexity of *O(n)*. This is already compensated by not requiring the `dist` vector.
-//!
-//! Furthermore, it allows to simplify the algorithm implementation by pushing the main complexity to the data structure; the algorithm now simply expresses the traversal and the update.
-//!
-//! ```rust ignore
-//! // Examine the frontier with lower cost nodes first (min-heap)
-//! while let Some((position, cost)) = heap.pop() {
-//!     // Alternatively we could have continued to find all shortest paths
-//!     if position == goal {
-//!         return Some(cost);
-//!     }
-//!
-//!     // For each node we can reach, see if we can find a way with
-//!     // a lower cost going through this node
-//!     for edge in &adj_list[position] {
-//!         heap.try_decrease_key_or_push(&edge.node, &(cost + edge.cost));
-//!     }
-//! }
-//! ```
-//!
-//! Note that `try_decrease_key_or_push` performs the following:
-//!
-//! * if the node already exists in the queue:
-//!     * when the new `key` is strictly less than the `node`'s current key; it decreases the key of the node to the given new `key`, and  returns true (a new shorter path is found, an indicator to udpate predecessor if shortest path is a required output in addition to shortest distance);
-//!     * otherwise, does not change the queue and returns false;
-//! * otherwise, pushes the `node` with the given `key` to the queue, and returns false.
-//!
-//! This is exactly what we need for Dijsktra's shortest path algorithm, and many node labelling algorithms. See [`PriorityQueueDecKey`] for other metods of the trait.
-//!
-//! See below, or [tests/dijkstra.rs](https://github.com/orxfun/orx-priority-queue/blob/main/tests/dijkstra.rs), for the complete implementation of the Dijkstra's shortest path algorithm with a `PriorityQueueDecKey`, adjusted from the standard BinaryHeap example.
-//!
-//!
-//! ```rust
-//! use orx_priority_queue::*;
-//!
-//! // Each node is represented as a `usize`, for a shorter implementation.
-//! struct Edge {
-//!     node: usize,
-//!     cost: usize,
-//! }
-//!
-//! // Dijkstra's shortest path algorithm.
-//!
-//! // Start at `start` and use `dist` to track the current shortest distance
-//! // to each node. This implementation isn't memory-efficient as it may leave duplicate
-//! // nodes in the queue. It also uses `usize::MAX` as a sentinel value,
-//! // for a simpler implementation.
-//! fn shortest_path(adj_list: &Vec<Vec<Edge>>, start: usize, goal: usize) -> Option<usize> {
-//!     let mut heap = BinaryHeapWithMap::default();
-//!
-//!     // We're at `start`, with a zero cost
-//!     heap.push(start, 0);
-//!
-//!     // Examine the frontier with lower cost nodes first (min-heap)
-//!     while let Some((position, cost)) = heap.pop() {
-//!         // Alternatively we could have continued to find all shortest paths
-//!         if position == goal {
-//!             return Some(cost);
-//!         }
-//!
-//!         // For each node we can reach, see if we can find a way with
-//!         // a lower cost going through this node
-//!         for edge in &adj_list[position] {
-//!             heap.try_decrease_key_or_push(&edge.node, &(cost + edge.cost));
-//!         }
-//!     }
-//!
-//!     // Goal not reachable
-//!     None
-//! }
-//!
-//! // This is the directed graph we're going to use.
-//! // The node numbers correspond to the different states,
-//! // and the edge weights symbolize the cost of moving
-//! // from one node to another.
-//! // Note that the edges are one-way.
-//! //
-//! //                  7
-//! //          +-----------------+
-//! //          |                 |
-//! //          v   1        2    |  2
-//! //          0 -----> 1 -----> 3 ---> 4
-//! //          |        ^        ^      ^
-//! //          |        | 1      |      |
-//! //          |        |        | 3    | 1
-//! //          +------> 2 -------+      |
-//! //           10      |               |
-//! //                   +---------------+
-//! //
-//! // The graph is represented as an adjacency list where each index,
-//! // corresponding to a node value, has a list of outgoing edges.
-//! // Chosen for its efficiency.
-//! let graph = vec![
-//!     // Node 0
-//!     vec![Edge { node: 2, cost: 10 }, Edge { node: 1, cost: 1 }],
-//!     // Node 1
-//!     vec![Edge { node: 3, cost: 2 }],
-//!     // Node 2
-//!     vec![
-//!         Edge { node: 1, cost: 1 },
-//!         Edge { node: 3, cost: 3 },
-//!         Edge { node: 4, cost: 1 },
-//!     ],
-//!     // Node 3
-//!     vec![Edge { node: 0, cost: 7 }, Edge { node: 4, cost: 2 }],
-//!     // Node 4
-//!     vec![],
-//! ];
-//!
-//! assert_eq!(shortest_path(&graph, 0, 1), Some(1));
-//! assert_eq!(shortest_path(&graph, 0, 3), Some(3));
-//! assert_eq!(shortest_path(&graph, 3, 0), Some(7));
-//! assert_eq!(shortest_path(&graph, 0, 4), Some(5));
-//! assert_eq!(shortest_path(&graph, 4, 0), None);
-//! ```
-//!
-//! ## Implementations
-//!
-//! ### d-ary heap
-//!
-//! The core [d-ary heap](https://en.wikipedia.org/wiki/D-ary_heap) is implemented thanks to const generics.
-//! Three structs are created from this core struct:
-//!
-//! * [`DaryHeap<N, K, const D: usize>`] which implements `PriorityQueue<N, K>` to be preferred when the additional
-//! features are not required.
-//! * [`DaryHeapWithMap<N, K, const D: usize>`] where `N: Hash + Equal` implements `PriorityQueueDecKey<N, K>`.
-//! It is a combination of the d-ary heap and a hash-map to track positions of nodes.
-//! This might be considered as the default way to extend the heap to enable additional funcitonalities without requiring a linear search.
-//! * [`DaryHeapOfIndices<N, K, const D: usize>`] where `N: HasIndex` implements `PriorityQueueDecKey<N, K>`.
-//! This variant is and alternative to the hash-map implementation and is particularly useful in algorithms where nodes to be enqueued are sampled from a closed set with known elements and the size of the queue is likely to get close to total number of candidates.
-//!
-//! ### Special traversal for d=2: binary-heap
-//!
-//! const generics further allows to use special arithmetics for the special case where d=2; i.e.,
-//! when d-ary heap is the binary heap.
-//! In particular, one addition/subtraction is avoided during the traversal through the tree.
-//!
-//! However, overall performance of the queues depends on the use case,
-//! ratio of push an decrease-key operations, etc.
-//! Benchmarks will follow.
+//! |                    |     |     | Queue Trait             | Queue Type               |
+//! |--------------------|-----|-----|-------------------------|--------------------------|
+//! | Memory Critical?   | yes |     |  `PriorityQueueDecKey`  |                          |
+//! | - Is Graph Sparse? |     | yes |                         |  `OrxDaryHeapOfIndices`  |
+//! |                    |     | no  |                         |  `OrxDaryHeapOfIndices`  |
+//! |.                   |     |     |                         |                          |
+//! | Memory Critical?   | no  |     |  `PriorityQueue`        |                          |
+//! | - Is Graph Sparse? |     | yes |                         |  `OrxDaryHeap`           |
+//! |                    |     | no  |                         |  `OrxDaryHeap` or `std::collections::BinaryHeap` |
 //!
 //!
 //! ## Example
@@ -248,11 +99,11 @@
 //!     pq.push(0, 42.0);
 //!     assert!(pq.contains(&0));
 //!
-//!     pq.decrease_key(&0, &7.0);
+//!     pq.decrease_key(&0, 7.0);
 //!     assert_eq!(Some(&(0, 7.0)), pq.peek());
 //!
-//!     let is_key_decreased = pq.try_decrease_key(&0, &10.0);
-//!     assert!(!is_key_decreased);
+//!     let res_try_deckey = pq.try_decrease_key(&0, 10.0);
+//!     assert_eq!(res_try_deckey, ResTryDecreaseKey::Unchanged);
 //!     assert_eq!(Some(&(0, 7.0)), pq.peek());
 //!
 //!     while let Some(popped) = pq.pop() {
@@ -265,30 +116,30 @@
 //!
 //! test_priority_queue(DaryHeap::<usize, f64, D>::default());
 //! test_priority_queue(DaryHeapWithMap::<usize, f64, D>::default());
-//! test_priority_queue(DaryHeapOfIndices::<usize, f64, D>::with_upper_limit(100));
+//! test_priority_queue(DaryHeapOfIndices::<usize, f64, D>::with_index_bound(100));
 //!
 //! test_priority_queue_deckey(DaryHeapWithMap::<usize, f64, D>::default());
-//! test_priority_queue_deckey(DaryHeapOfIndices::<usize, f64, D>::with_upper_limit(100));
+//! test_priority_queue_deckey(DaryHeapOfIndices::<usize, f64, D>::with_index_bound(100));
 //!
 //! // or type aliases for common heaps to simplify signature
 //! // Binary, Ternary or Quarternary to fix D of Dary
 //! test_priority_queue(BinaryHeap::default());
 //! test_priority_queue(BinaryHeapWithMap::default());
-//! test_priority_queue(BinaryHeapOfIndices::with_upper_limit(100));
+//! test_priority_queue(BinaryHeapOfIndices::with_index_bound(100));
 //! test_priority_queue_deckey(BinaryHeapWithMap::default());
-//! test_priority_queue_deckey(BinaryHeapOfIndices::with_upper_limit(100));
+//! test_priority_queue_deckey(BinaryHeapOfIndices::with_index_bound(100));
 //!
 //! test_priority_queue(TernaryHeap::default());
 //! test_priority_queue(TernaryHeapWithMap::default());
-//! test_priority_queue(TernaryHeapOfIndices::with_upper_limit(100));
+//! test_priority_queue(TernaryHeapOfIndices::with_index_bound(100));
 //! test_priority_queue_deckey(TernaryHeapWithMap::default());
-//! test_priority_queue_deckey(TernaryHeapOfIndices::with_upper_limit(100));
+//! test_priority_queue_deckey(TernaryHeapOfIndices::with_index_bound(100));
 //!
 //! test_priority_queue(QuarternaryHeap::default());
 //! test_priority_queue(QuarternaryHeapWithMap::default());
-//! test_priority_queue(QuarternaryHeapOfIndices::with_upper_limit(100));
+//! test_priority_queue(QuarternaryHeapOfIndices::with_index_bound(100));
 //! test_priority_queue_deckey(QuarternaryHeapWithMap::default());
-//! test_priority_queue_deckey(QuarternaryHeapOfIndices::with_upper_limit(100));
+//! test_priority_queue_deckey(QuarternaryHeapOfIndices::with_index_bound(100));
 //! ```
 //!
 //! ## License
@@ -322,4 +173,7 @@ pub use dary::daryheap_map::{
 };
 pub use has_index::HasIndex;
 pub use priority_queue::PriorityQueue;
-pub use priority_queue_deckey::PriorityQueueDecKey;
+pub use priority_queue_deckey::{
+    PriorityQueueDecKey, ResDecreaseKeyOrPush, ResTryDecreaseKey, ResTryDecreaseKeyOrPush,
+    ResUpdateKey, ResUpdateKeyOrPush,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,9 @@
     clippy::missing_panics_doc,
     clippy::todo
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod dary;
 mod has_index;

--- a/src/positions/has_index.rs
+++ b/src/positions/has_index.rs
@@ -17,13 +17,13 @@ impl<N> HeapPositionsHasIndex<N>
 where
     N: HasIndex,
 {
-    pub fn with_upper_limit(upper_limit: usize) -> Self {
+    pub fn with_index_bound(index_bound: usize) -> Self {
         Self {
-            positions: vec![NONE; upper_limit],
+            positions: vec![NONE; index_bound],
             ph: PhantomData,
         }
     }
-    pub(crate) fn upper_limit(&self) -> usize {
+    pub(crate) fn index_bound(&self) -> usize {
         self.positions.len()
     }
 }

--- a/src/positions/has_index.rs
+++ b/src/positions/has_index.rs
@@ -1,6 +1,8 @@
 use super::heap_positions::{HeapPositions, HeapPositionsDecKey};
 use crate::HasIndex;
-use std::marker::PhantomData;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 /// using usize::MAX as None
 const NONE: usize = usize::MAX;

--- a/src/positions/map.rs
+++ b/src/positions/map.rs
@@ -1,36 +1,56 @@
 use super::heap_positions::{HeapPositions, HeapPositionsDecKey};
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
 use std::{collections::HashMap, hash::Hash};
+
+#[cfg(not(feature = "std"))]
+pub trait Index: Eq + Clone + Ord {}
+#[cfg(not(feature = "std"))]
+impl<T> Index for T where T: Eq + Clone + Ord {}
+#[cfg(feature = "std")]
+pub trait Index: Eq + Clone + Hash {}
+#[cfg(feature = "std")]
+impl<T> Index for T where T: Eq + Clone + Hash {}
+
+#[cfg(not(feature = "std"))]
+type Map<N> = BTreeMap<N, usize>;
+#[cfg(feature = "std")]
+type Map<N> = HashMap<N, usize>;
 
 #[derive(Clone, Debug)]
 pub struct HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
-    map: HashMap<N, usize>,
+    map: Map<N>,
 }
 impl<N> Default for HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
     fn default() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
+        Self { map: Map::new() }
     }
 }
 impl<N> HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
+    #[allow(unused)]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            map: HashMap::with_capacity(capacity),
+            #[cfg(not(std))]
+            map: Map::new(),
+            #[cfg(std)]
+            map: Map::with_capacity(capacity),
         }
     }
 }
 impl<N> HeapPositions<N> for HeapPositionsMap<N>
 where
-    N: Eq + Hash + Clone,
+    N: Index,
 {
     fn clear(&mut self) {
         self.map.clear();
@@ -72,4 +92,4 @@ where
     }
 }
 
-impl<N> HeapPositionsDecKey<N> for HeapPositionsMap<N> where N: Eq + Hash + Clone {}
+impl<N> HeapPositionsDecKey<N> for HeapPositionsMap<N> where N: Index {}

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -5,35 +5,203 @@ where
     K: PartialOrd,
 {
     /// Number of elements in the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = DaryHeap::<_, _, 16>::default();
+    ///
+    /// queue.push('a', 42);
+    /// queue.push('b', 7);
+    /// assert_eq!(2, queue.len());
+    ///
+    /// _ = queue.pop();
+    /// assert_eq!(1, queue.len());
+    /// ```
     fn len(&self) -> usize;
+    // todo: documentation
+    /// Capacity of the heap.
+    fn capacity(&self) -> usize;
 
     /// Returns whether he queue is empty or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = QuarternaryHeap::default();
+    /// assert!(queue.is_empty());
+    ///
+    /// queue.push("wisdom", 42);
+    /// assert!(!queue.is_empty());
+    /// ```
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Returns the nodes and keys currently in the queue as a slice;
     /// not necessarily sorted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = QuarternaryHeapWithMap::default();
+    /// queue.push("x", 42);
+    /// queue.push("y", 7);
+    /// queue.push("z", 99);
+    ///
+    /// let slice = queue.as_slice();
+    ///
+    /// assert_eq!(3, slice.len());
+    /// assert!(slice.contains(&("x", 42)));
+    /// assert!(slice.contains(&("y", 7)));
+    /// assert!(slice.contains(&("z", 99)));
+    /// ```
     fn as_slice(&self) -> &[(N, K)];
 
     /// Returns, without popping, a reference to the foremost element of the queue;
     /// returns None if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeap::default();
+    /// assert_eq!(None, queue.peek());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert_eq!(Some(&(42, 1.0)), queue.peek());
+    /// ```
     fn peek(&self) -> Option<&(N, K)>;
 
     /// Clears the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = TernaryHeap::default();
+    /// assert!(queue.is_empty());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert!(!queue.is_empty());
+    ///
+    /// queue.clear();
+    /// assert!(queue.is_empty());
+    /// ```
     fn clear(&mut self);
 
     /// Removes and returns the (node, key) pair with the lowest key in the queue;
     /// returns None if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeap::default();
+    /// assert_eq!(None, queue.pop());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert_eq!(3, queue.len());
+    ///
+    /// assert_eq!(Some((42, 1.0)), queue.pop());
+    /// assert_eq!(2, queue.len());
+    ///
+    /// assert_eq!(Some((21, 5.0)), queue.pop());
+    /// assert_eq!(1, queue.len());
+    ///
+    /// assert_eq!(Some((0, 12.0)), queue.pop());
+    /// assert!(queue.is_empty());
+    ///
+    /// assert_eq!(None, queue.pop());
+    /// ```
     fn pop(&mut self) -> Option<(N, K)>;
     /// Removes and returns the node with the lowest key in the queue;
     /// returns None if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeap::default();
+    /// assert_eq!(None, queue.pop_node());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert_eq!(3, queue.len());
+    ///
+    /// assert_eq!(Some(42), queue.pop_node());
+    /// assert_eq!(2, queue.len());
+    ///
+    /// assert_eq!(Some(21), queue.pop_node());
+    /// assert_eq!(1, queue.len());
+    ///
+    /// assert_eq!(Some(0), queue.pop_node());
+    /// assert!(queue.is_empty());
+    ///
+    /// assert_eq!(None, queue.pop_node());
+    /// ```
     fn pop_node(&mut self) -> Option<N>;
     /// Removes and returns the key of the node with the lowest key in the queue;
     /// returns None if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeap::default();
+    /// assert_eq!(None, queue.pop_key());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert_eq!(3, queue.len());
+    ///
+    /// assert_eq!(Some(1.0), queue.pop_key());
+    /// assert_eq!(2, queue.len());
+    ///
+    /// assert_eq!(Some(5.0), queue.pop_key());
+    /// assert_eq!(1, queue.len());
+    ///
+    /// assert_eq!(Some(12.0), queue.pop_key());
+    /// assert!(queue.is_empty());
+    ///
+    /// assert_eq!(None, queue.pop_key());
+    /// ```
     fn pop_key(&mut self) -> Option<K>;
 
     /// Pushes the given (`node`, `key`) pair to the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeap::default();
+    /// assert!(queue.is_empty());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert_eq!(3, queue.len());
+    /// ```
     fn push(&mut self, node: N, key: K);
 
     /// Performs the push with given (`node`, `key`) followed by the pop operation.
@@ -42,6 +210,42 @@ where
     ///
     /// The reason of merging the calls is that handling two instructions at once
     /// is more efficient for certain implementations, such as for the binary heap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeap::default();
+    /// assert!(queue.is_empty());
+    ///
+    /// // returns the (node, key) back qhen the queue is empty
+    /// let popped = queue.push_then_pop(3, 33.3);
+    /// assert_eq!((3, 33.3), popped);
+    /// assert!(queue.is_empty());
+    ///
+    /// queue.push(0, 12.0);
+    /// queue.push(42, 1.0);
+    /// queue.push(21, 5.0);
+    /// assert_eq!(3, queue.len()); // sorted-nodes: 42 (1.0) << 21 (5.0) << 0 (12.0)
+    ///
+    /// let popped = queue.push_then_pop(100, 100.0);
+    /// assert_eq!((42, 1.0), popped);
+    /// assert_eq!(3, queue.len()); // sorted-nodes: 21 (5.0) << 0 (12.0) << 100 (100.0)
+    ///
+    /// let popped = queue.push_then_pop(6, 6.0);
+    /// assert_eq!((21, 5.0), popped);
+    /// assert_eq!(3, queue.len()); // sorted-nodes: 6 (6.0) << 0 (12.0) << 100 (100.0)
+    ///
+    /// let popped = queue.push_then_pop(13, 13.0);
+    /// assert_eq!((6, 6.0), popped);
+    /// assert_eq!(3, queue.len()); // sorted-nodes: 0 (12.0) << 13 (13.0) << 100 (100.0)
+    ///
+    /// assert_eq!(Some((0, 12.0)), queue.pop());
+    /// assert_eq!(Some((13, 13.0)), queue.pop());
+    /// assert_eq!(Some((100, 100.0)), queue.pop());
+    /// assert!(queue.is_empty());
+    /// ```
     fn push_then_pop(&mut self, node: N, key: K) -> (N, K);
 
     /// Test method which returns whether or not the queue is valid.

--- a/src/priority_queue_deckey.rs
+++ b/src/priority_queue_deckey.rs
@@ -24,139 +24,291 @@ where
     K: PartialOrd + Clone,
 {
     /// Returns whether the given `node` is in the queue or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapWithMap::default();
+    /// queue.push('a', 42);
+    ///
+    /// assert!(queue.contains(&'a'));
+    /// assert!(!queue.contains(&'x'));
+    /// ```
     fn contains(&self, node: &N) -> bool;
 
     /// Returns the key of the given `node` if it is in the queue;
     /// returns None otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapOfIndices::with_index_bound(12);
+    /// queue.push(7usize, 42.0);
+    ///
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    /// assert_eq!(None, queue.key_of(&3));
+    /// ```
     fn key_of(&self, node: &N) -> Option<K>;
 
     /// Decreases key of the `node` which is already in the queue to the given `decreased_key`.
-    /// This method is commonly use to increase priority of a node;
-    /// rather than to re-insert it to keep the size of the queue smaller.
+    ///
+    /// This method is commonly used to increase priority of a node putting it closer to the peek of the queue;
+    /// alternative to inserting the same node multiple times with different keys.
+    /// This allows for memory efficient implementations of certain algorithms such as the
+    /// Dijkstra's shortest path algorithm.
     ///
     /// # Panics
-    /// This method panics if:
-    /// * the `node` is not in the queue; or
-    /// * `decreased_key` is strictly larget than key of the `node` in the queue.
+    /// This method panics:
+    /// * if the `node` is not in the queue; or
+    ///     * see [`PriorityQueueDecKey::try_decrease_key_or_push`] for a variant which pushes the
+    /// `(node, new_key)` pair if the `node` is absent, rather than panicking;
+    /// * if `decreased_key` is strictly larger than key of the `node` in the queue,
+    ///     * see [`PriorityQueueDecKey::try_decrease_key`] for a variant which does nothing
+    /// if the new key is strictly larger than key of the `node` in the queue, rather than panicking.
     ///
-    /// # See also
-    /// Note that the following methods have minor but important differences
-    /// making them suitable for different cases/algorithms:
-    /// `decrease_key`, `update_key`, `try_decrease_key`, `decrease_key_or_push`, `update_key_or_push` and `try_decrease_key_or_push`.
-    fn decrease_key(&mut self, node: &N, decreased_key: &K);
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapOfIndices::with_index_bound(12);
+    ///
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// queue.decrease_key(&7, 21.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    ///
+    /// // the following lines would've panicked:
+    /// // queue.decrease_key(&10, 21.0); // due to absent node
+    /// // queue.decrease_key(&7, 100.0); // due to greater new key
+    /// ```
+    fn decrease_key(&mut self, node: &N, decreased_key: K);
     /// Updates key of the `node` which is already in the queue as the given `new_key`;
-    /// and returns whether the node's key is strictly decreased or not.
+    /// and returns the result of the operation:
+    ///
+    /// * `ResUpdateKey::Decreased` if the prior key was strictly greater than the `new_key`;
+    /// * `ResUpdateKey::Increased` if the prior key was less than or equal to the `new_key`.
+    ///
+    /// # Panics
+    /// This method panics if:
+    /// * the `node` is not in the queue,
+    ///     * see [`PriorityQueueDecKey::update_key_or_push`] for a variant which pushes the
+    /// `(node, new_key)` pair if the `node` is absent, rather than panicking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapWithMap::default();
+    ///
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// let result = queue.update_key(&7, 21.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResUpdateKey::Decreased));
+    ///
+    /// let result = queue.update_key(&7, 200.0);
+    /// assert_eq!(Some(200.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResUpdateKey::Increased));
+    ///
+    /// // the following line would've panicked:
+    /// // queue.update_key(&10, 21.0); // due to absent node
+    /// ```
+    fn update_key(&mut self, node: &N, new_key: K) -> ResUpdateKey;
+    /// Tries to decrease the key of the `node` which is already in the queue if its prior key is strictly larger than the `new_key`;
+    /// otherwise, it does nothing leaving the queue unchanged.
+    ///
+    /// Returns the result of the operation:
+    ///
+    /// * `ResTryDecreaseKey::Decreased` if the prior key was strictly greater than the `new_key`;
+    /// * `ResTryDecreaseKey::Unchanged` if the prior key was less than or equal to the `new_key`.
     ///
     /// # Panics
     /// This method panics if:
     /// * the `node` is not in the queue.
     ///
-    /// # See also
-    /// Note that the following methods have minor but important differences
-    /// making them suitable for different cases/algorithms:
-    /// `decrease_key`, `update_key`, `try_decrease_key`, `decrease_key_or_push`, `update_key_or_push` and `try_decrease_key_or_push`.
-    fn update_key(&mut self, node: &N, new_key: &K) -> bool;
-    /// This method:
-    /// * when `new_key` is strictly less than the `node`'s current key:
-    ///     * decreases the key of the node to the given `new_key`, and
-    ///     * returns true;
-    /// * otherwise:
-    ///     * does not change the queue, and
-    ///     * returns false.
+    /// # Examples
     ///
-    /// In brief, the method returns whether the key of the `node` is decreased or not.
+    /// ```
+    /// use orx_priority_queue::*;
     ///
-    /// # Panics
-    /// This method panics if:
-    /// * the `node` is not in the queue.
+    /// let mut queue = BinaryHeapOfIndices::with_index_bound(12);
     ///
-    /// # See also
-    /// Note that the following methods have minor but important differences
-    /// making them suitable for different cases/algorithms:
-    /// `decrease_key`, `update_key`, `try_decrease_key`, `decrease_key_or_push`, `update_key_or_push` and `try_decrease_key_or_push`.
-    fn try_decrease_key(&mut self, node: &N, new_key: &K) -> bool {
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// let result = queue.try_decrease_key(&7, 21.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResTryDecreaseKey::Decreased));
+    ///
+    /// let result = queue.try_decrease_key(&7, 200.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResTryDecreaseKey::Unchanged));
+    ///
+    /// // the following line would've panicked:
+    /// // queue.decrease_key(&10, 21.0); // due to absent node
+    /// ```
+    #[inline(always)]
+    fn try_decrease_key(&mut self, node: &N, new_key: K) -> ResTryDecreaseKey {
         let old_key = self.key_of(node).expect("node must exist on the heap.");
-        if new_key < &old_key {
+        if new_key < old_key {
             self.decrease_key(node, new_key);
-            true
+            ResTryDecreaseKey::Decreased
         } else {
-            false
+            ResTryDecreaseKey::Unchanged
         }
     }
 
-    /// This method
-    /// * when the `node` is present in the queue:
-    ///     * decreases its key to the given new `key` which is expected to be less than or equal to the current key, and
-    ///     * returns true;
-    /// * otherwise:
-    ///     * pushes the `node` with the given `key` to the queue, and
-    ///     * returns false.
+    /// If the `node` is present in the queue:
+    /// * decreases key of the `node` to the given `decreased_key`; `decreased_key` is expected to be less than or equal
+    /// to the prior key;
     ///
-    /// In brief, the method returns whether the key of the `node` is decreased or not.
+    /// otherwise:
+    /// * pushes the new (node, key) pair to the queue.
+    ///
+    /// Returns the result of the operation:
+    ///
+    /// * `ResDecreaseKeyOrPush::Decreased` if the `node` was present in the queue and its key is decreased to `decreased_key`;
+    /// * `ResDecreaseKeyOrPush::Pushed` if the `node` was absent and it is pushed with the given `decreased_key`.
     ///
     /// # Panics
-    /// This method panics if:
-    /// * the `node` is in the queue; however, its current key is strictly less than the provided `key`.
+    /// This method panics
+    /// * if the `node` is in the queue; however, its current key is strictly less than the provided `key`;
+    ///     * see [`PriorityQueueDecKey::update_key_or_push`] for a variant which increases the key
+    /// if the new key is strictly larger than key of the `node` in the queue, rather than panicking; or
+    ///     * see [`PriorityQueueDecKey::try_decrease_key_or_push`] for a variant which does nothing
+    /// if the new key is strictly larger than key of the `node` in the queue, rather than panicking.
     ///
-    /// # See also
-    /// Note that the following methods have minor but important differences
-    /// making them suitable for different cases/algorithms:
-    /// `decrease_key`, `update_key`, `try_decrease_key`, `decrease_key_or_push`, `update_key_or_push` and `try_decrease_key_or_push`.
-    fn decrease_key_or_push(&mut self, node: &N, key: &K) -> bool {
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapOfIndices::with_index_bound(12);
+    ///
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// let result = queue.decrease_key_or_push(&7, 21.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResDecreaseKeyOrPush::Decreased));
+    ///
+    /// let result = queue.decrease_key_or_push(&0, 10.0);
+    /// assert_eq!(Some(10.0), queue.key_of(&0));
+    /// assert!(matches!(result, ResDecreaseKeyOrPush::Pushed));
+    ///
+    /// // the following line would've panicked:
+    /// // queue.decrease_key_or_push(&7, 100.0); // due to greater new key
+    /// ```
+    #[inline(always)]
+    fn decrease_key_or_push(&mut self, node: &N, key: K) -> ResDecreaseKeyOrPush {
         if self.contains(node) {
             self.decrease_key(node, key);
-            true
+            ResDecreaseKeyOrPush::Decreased
         } else {
             self.push(node.clone(), key.clone());
-            false
+            ResDecreaseKeyOrPush::Pushed
         }
     }
-    /// This method
-    /// * when the `node` is present in the queue:
-    ///     * updates its key to the given new `key`, and
-    ///     * returns whether the update operation strictly decreased the node's key or not;
-    /// * otherwise:
-    ///     * pushes the `node` with the given `key` to the queue, and
-    ///     * returns false.
+    /// If the `node` is present in the queue:
+    /// * updates key of the `node` to the given `new_key`;
     ///
-    /// In brief, the method returns whether the key of the `node` is decreased or not.
+    /// otherwise:
+    /// * pushes the new (node, key) pair to the queue.
     ///
-    /// # See also
-    /// Note that the following methods have minor but important differences
-    /// making them suitable for different cases/algorithms:
-    /// `decrease_key`, `update_key`, `try_decrease_key`, `decrease_key_or_push`, `update_key_or_push` and `try_decrease_key_or_push`.
-    fn update_key_or_push(&mut self, node: &N, key: &K) -> bool {
+    /// Returns the result of the operation:
+    ///
+    /// * `ResUpdateKeyOrPush::Decreased` if the `node` was present in the queue with a key strictly larger than the `new_key`;
+    /// * `ResUpdateKeyOrPush::Increased` if the `node` was present in the queue with a key less than or equal to the `new_key`;
+    /// * `ResUpdateKeyOrPush::Pushed` if the `node` was absent and it is pushed with the given `new_key`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapWithMap::default();
+    ///
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// let result = queue.update_key_or_push(&7, 21.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResUpdateKeyOrPush::Decreased));
+    ///
+    /// let result = queue.update_key_or_push(&7, 200.0);
+    /// assert_eq!(Some(200.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResUpdateKeyOrPush::Increased));
+    ///
+    /// let result = queue.update_key_or_push(&0, 10.0);
+    /// assert_eq!(Some(10.0), queue.key_of(&0));
+    /// assert!(matches!(result, ResUpdateKeyOrPush::Pushed));
+    /// ```
+    fn update_key_or_push(&mut self, node: &N, key: K) -> ResUpdateKeyOrPush {
         if self.contains(node) {
-            self.update_key(node, key)
+            self.update_key(node, key).into()
         } else {
             self.push(node.clone(), key.clone());
-            false
+            ResUpdateKeyOrPush::Pushed
         }
     }
-    /// This method
-    /// * when the `node` is present in the queue:
-    ///     * when the new `key` is strictly less than the `node`'s current key:
-    ///         * decreases the key of the node to the given `key`, and
-    ///         * returns true;
-    ///     * otherwise:
-    ///         * does not change the queue, and
-    ///         * returns false;
-    /// * otherwise:
-    ///     * pushes the `node` with the given `key` to the queue, and
-    ///     * returns false.
+    /// If the `node` is present in the queue, tries to decrease its key to the given `key`:
+    /// * its key is set to the new `key` if the prior key was strictly larger than the given key;
+    /// * the queue remains unchanged if the prior key was less than or equal to the given key;
     ///
-    /// In brief, the method returns whether the key of the `node` is decreased or not.
+    /// otherwise, if the `node` is absent:
+    /// * the new (node, key) pair is pushed to the queue.
     ///
-    /// # See also
-    /// Note that the following methods have minor but important differences
-    /// making them suitable for different cases/algorithms:
-    /// `decrease_key`, `update_key`, `try_decrease_key`, `decrease_key_or_push`, `update_key_or_push` and `try_decrease_key_or_push`.
-    fn try_decrease_key_or_push(&mut self, node: &N, key: &K) -> bool {
-        if self.contains(node) {
-            self.try_decrease_key(node, key)
-        } else {
-            self.push(node.clone(), key.clone());
-            false
+    /// Returns the result of the operation:
+    ///
+    /// * `ResTryDecreaseKeyOrPush::Decreased` if the `node` was present in the queue with a key strictly larger than the `key`;
+    /// * `ResTryDecreaseKeyOrPush::Unchanged` if the `node` was present in the queue with a key less than or equal to the `key`;
+    /// * `ResTryDecreaseKeyOrPush::Pushed` if the `node` was absent and it is pushed with the given `new_key`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapOfIndices::with_index_bound(12);
+    ///
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// let result = queue.try_decrease_key_or_push(&7, 21.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResTryDecreaseKeyOrPush::Decreased));
+    ///
+    /// let result = queue.try_decrease_key_or_push(&7, 200.0);
+    /// assert_eq!(Some(21.0), queue.key_of(&7));
+    /// assert!(matches!(result, ResTryDecreaseKeyOrPush::Unchanged));
+    ///
+    /// let result = queue.try_decrease_key_or_push(&0, 10.0);
+    /// assert_eq!(Some(10.0), queue.key_of(&0));
+    /// assert!(matches!(result, ResTryDecreaseKeyOrPush::Pushed));
+    /// ```
+    #[inline(always)]
+    fn try_decrease_key_or_push(&mut self, node: &N, key: K) -> ResTryDecreaseKeyOrPush {
+        match self.key_of(node) {
+            Some(old_key) => {
+                if key < old_key {
+                    self.decrease_key(node, key);
+                    ResTryDecreaseKeyOrPush::Decreased
+                } else {
+                    ResTryDecreaseKeyOrPush::Unchanged
+                }
+            }
+            None => {
+                self.push(node.clone(), key.clone());
+                ResTryDecreaseKeyOrPush::Pushed
+            }
         }
     }
 
@@ -165,5 +317,85 @@ where
     /// # Panics
     /// This method panics if:
     /// * the `node` is not in the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_priority_queue::*;
+    ///
+    /// let mut queue = BinaryHeapWithMap::default();
+    ///
+    /// queue.push(7usize, 42.0);
+    /// assert_eq!(Some(42.0), queue.key_of(&7));
+    ///
+    /// let key = queue.remove(&7);
+    /// assert_eq!(42.0, key);
+    /// assert!(queue.is_empty());
+    ///
+    /// // the following line would've panicked due to absent node
+    /// // let key = queue.remove(&7);
+    /// ```
     fn remove(&mut self, node: &N) -> K;
+}
+
+/// Result of `queue.update_key(node, new_key)` operation : [`PriorityQueueDecKey::update_key`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResUpdateKey {
+    /// Existing key of the `node` was higher; and hence, decreased to the `new_key`.
+    Decreased,
+    /// Existing key of the `node` was lower; and hence, increased to the `new_key`.
+    Increased,
+}
+/// Result of `queue.try_decrease_key(node, new_key)` operation : [`PriorityQueueDecKey::try_decrease_key`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResTryDecreaseKey {
+    /// Existing key of the `node` was higher; and hence, decreased to the `new_key`.
+    Decreased,
+    /// Existing key of the `node` was lower; and hence, the queue is not changed.
+    Unchanged,
+}
+/// Result of `queue.decrease_key_or_push(node, key)` operation : [`PriorityQueueDecKey::decrease_key_or_push`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResDecreaseKeyOrPush {
+    /// The `node` did not exist in the queue; and hence, pushed to the queue with the given `key`.
+    Pushed,
+    /// The `node` existed in the queue, its key was higher; and hence, decreased to the given `key`.
+    Decreased,
+}
+/// Result of `queue.update_key_or_push(node, key)` operation : [`PriorityQueueDecKey::update_key_or_push`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResUpdateKeyOrPush {
+    /// The `node` did not exist in the queue; and hence, pushed to the queue with the given `key`.
+    Pushed,
+    /// The `node` existed in the queue, its key was higher; and hence, decreased to the given `key`.
+    Decreased,
+    /// The `node` existed in the queue, its key was lower; and hence, increased to the given `key`.
+    Increased,
+}
+/// Result of `queue.try_decrease_key_or_push(node, key)` operation : [`PriorityQueueDecKey::try_decrease_key_or_push`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResTryDecreaseKeyOrPush {
+    /// The `node` did not exist in the queue; and hence, pushed to the queue with the given `key`.
+    Pushed,
+    /// The `node` existed in the queue, its key was higher; and hence, decreased to the given `key`.
+    Decreased,
+    /// The `node` existed in the queue, its key was lower; and hence, the queue is not changed.
+    Unchanged,
+}
+
+impl From<ResUpdateKey> for ResUpdateKeyOrPush {
+    fn from(value: ResUpdateKey) -> Self {
+        match value {
+            ResUpdateKey::Decreased => Self::Decreased,
+            ResUpdateKey::Increased => Self::Increased,
+        }
+    }
+}
+impl From<ResTryDecreaseKey> for ResTryDecreaseKeyOrPush {
+    fn from(value: ResTryDecreaseKey) -> Self {
+        match value {
+            ResTryDecreaseKey::Decreased => Self::Decreased,
+            ResTryDecreaseKey::Unchanged => Self::Unchanged,
+        }
+    }
 }

--- a/tests/daryheap.rs
+++ b/tests/daryheap.rs
@@ -13,6 +13,8 @@ fn test_dary_forall() {
         test_dary_for::<8>();
         test_dary_for::<13>();
         test_dary_for::<16>();
+        test_dary_for::<32>();
+        test_dary_for::<64>();
     }
 }
 

--- a/tests/daryheap_of_indices.rs
+++ b/tests/daryheap_of_indices.rs
@@ -15,11 +15,13 @@ fn test_dary_forall() {
         test_dary_for::<8>();
         test_dary_for::<13>();
         test_dary_for::<16>();
+        test_dary_for::<32>();
+        test_dary_for::<64>();
     }
 }
 
 fn test_dary_for<const D: usize>() {
-    let new_heap = || DaryHeapOfIndices::<usize, f64, D>::with_upper_limit(125);
+    let new_heap = || DaryHeapOfIndices::<usize, f64, D>::with_index_bound(125);
 
     let change_key = [
         ChangeKeyMethod::Decrease,

--- a/tests/daryheap_of_indices_2.rs
+++ b/tests/daryheap_of_indices_2.rs
@@ -8,7 +8,7 @@ use priority_queue_tests::*;
 const D: usize = 2;
 
 fn new_heap() -> DaryHeapOfIndices<usize, f64, D> {
-    DaryHeapOfIndices::with_upper_limit(125)
+    DaryHeapOfIndices::with_index_bound(125)
 }
 
 #[test]

--- a/tests/daryheap_of_indices_4.rs
+++ b/tests/daryheap_of_indices_4.rs
@@ -8,7 +8,7 @@ use priority_queue_tests::*;
 const D: usize = 4;
 
 fn new_heap() -> DaryHeapOfIndices<usize, f64, D> {
-    DaryHeapOfIndices::with_upper_limit(125)
+    DaryHeapOfIndices::with_index_bound(125)
 }
 
 #[test]

--- a/tests/daryheap_with_map.rs
+++ b/tests/daryheap_with_map.rs
@@ -15,6 +15,8 @@ fn test_dary_forall() {
         test_dary_for::<8>();
         test_dary_for::<13>();
         test_dary_for::<16>();
+        test_dary_for::<32>();
+        test_dary_for::<64>();
     }
 }
 

--- a/tests/dijkstra.rs
+++ b/tests/dijkstra.rs
@@ -30,7 +30,7 @@ fn dijkstra() {
             // For each node we can reach, see if we can find a way with
             // a lower cost going through this node
             for edge in &adj_list[position] {
-                heap.try_decrease_key_or_push(&edge.node, &(cost + edge.cost));
+                _ = heap.try_decrease_key_or_push(&edge.node, cost + edge.cost);
             }
         }
 

--- a/tests/priority_queue_deckey_tests/change_key.rs
+++ b/tests/priority_queue_deckey_tests/change_key.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use orx_priority_queue::PriorityQueueDecKey;
+use orx_priority_queue::{PriorityQueueDecKey, ResTryDecreaseKey, ResUpdateKey};
 use rand::prelude::*;
 use std::cmp::Ordering;
 
@@ -43,18 +43,24 @@ where
 
         match change_key {
             ChangeKeyMethod::Decrease => {
-                pq.decrease_key(&node, &new_key);
+                pq.decrease_key(&node, new_key);
                 vec[node] = (node, new_key);
             }
             ChangeKeyMethod::Update => {
-                let decreased = pq.update_key(&node, &new_key);
-                assert_eq!(new_key < old_key, decreased);
+                let res_updkey = pq.update_key(&node, new_key);
+                assert_eq!(
+                    new_key < old_key,
+                    matches!(res_updkey, ResUpdateKey::Decreased)
+                );
                 vec[node] = (node, new_key);
             }
             ChangeKeyMethod::TryDecrease => {
-                let decreased = pq.try_decrease_key(&node, &new_key);
-                assert_eq!(new_key < old_key, decreased);
-                if decreased {
+                let res_try_deckey = pq.try_decrease_key(&node, new_key);
+                assert_eq!(
+                    new_key < old_key,
+                    matches!(res_try_deckey, ResTryDecreaseKey::Decreased)
+                );
+                if matches!(res_try_deckey, ResTryDecreaseKey::Decreased) {
                     vec[node] = (node, new_key);
                 }
             }

--- a/tests/priority_queue_deckey_tests/change_key_or_push.rs
+++ b/tests/priority_queue_deckey_tests/change_key_or_push.rs
@@ -1,6 +1,6 @@
 use super::ChangeKeyMethod;
 use itertools::Itertools;
-use orx_priority_queue::PriorityQueueDecKey;
+use orx_priority_queue::{PriorityQueueDecKey, ResTryDecreaseKeyOrPush, ResUpdateKeyOrPush};
 use rand::prelude::*;
 use std::cmp::Ordering;
 
@@ -44,22 +44,22 @@ where
 
         match change_key {
             ChangeKeyMethod::Decrease => {
-                pq.decrease_key_or_push(&node, &new_key);
+                pq.decrease_key_or_push(&node, new_key);
                 vec[node] = Some(new_key);
             }
             ChangeKeyMethod::Update => {
-                let decreased = pq.update_key_or_push(&node, &new_key);
+                let res_updkey_push = pq.update_key_or_push(&node, new_key);
                 assert_eq!(
                     old_key.map(|old_key| new_key < old_key).unwrap_or(false),
-                    decreased
+                    matches!(res_updkey_push, ResUpdateKeyOrPush::Decreased)
                 );
                 vec[node] = Some(new_key);
             }
             ChangeKeyMethod::TryDecrease => {
-                let decreased = pq.try_decrease_key_or_push(&node, &new_key);
+                let res_try_deckey_push = pq.try_decrease_key_or_push(&node, new_key);
                 assert_eq!(
                     old_key.map(|old_key| new_key < old_key).unwrap_or(false),
-                    decreased
+                    matches!(res_try_deckey_push, ResTryDecreaseKeyOrPush::Decreased)
                 );
                 if old_key.is_none() || new_key < old_key.unwrap() {
                     vec[node] = Some(new_key);


### PR DESCRIPTION
* const generics utilized for arithmetic operations for d where d = 2^k for integer k, rather than only for k=1.
* `PriorityQueueDecKey` methods such as `try_decrease_key` return enums rather than bools to be explicit about the carried out operation. *