### PR TITLE
Add missing no_std attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,7 @@
     clippy::missing_panics_doc,
     clippy::todo
 )]
+#![no_std]
 
 #[cfg(any(test, feature = "std"))]
 extern crate std;


### PR DESCRIPTION
It seems like it got lost, everything else still works (verified with `cargo no-std-check --no-default-features` and `cargo check --target wasm32v1-none --no-default-features`).

Thanks for your work!